### PR TITLE
LPS-62661 Get the right node if there are no documents or folders

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/upload.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/upload.js
@@ -471,7 +471,12 @@ AUI.add(
 								entriesContainerSelector = 'ul.list-unstyled:last-of-type';
 							}
 
-							entriesContainer = entriesContainer.one(entriesContainerSelector);
+							if (entriesContainer.one(entriesContainerSelector)) {
+								entriesContainer = entriesContainer.one(entriesContainerSelector);
+							}
+							else {
+								entriesContainer = entriesContainer.one('.taglib-empty-result-message');
+							}
 
 							var invisibleEntry = instance._invisibleDescriptiveEntry;
 


### PR DESCRIPTION
Chema, este commit arregla el D&D en la Documents and Media cuando no hay ni carpetas ni documentos en la vista de icono y descriptive, pero en la vista de tabla sigue fallando.

Puedes ver si podemos arreglar la vista de tabla facilmente?

Gracias!