### PR TITLE
LPS-70758 Remove unnecessary calls to themeDisplay.isImpersonated (vm)

### DIFF
--- a/modules/apps/foundation/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/templates/init.ftl
+++ b/modules/apps/foundation/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/templates/init.ftl
@@ -79,6 +79,10 @@
 	/>
 </#if>
 
+<#if !is_setup_complete>
+	<#assign is_setup_complete = theme_display.isImpersonated() />
+</#if>
+
 <#-- ---------- URLs ---------- -->
 
 <#assign show_control_panel = theme_display.isShowControlPanelIcon() />

--- a/modules/apps/foundation/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/templates/init.vm
+++ b/modules/apps/foundation/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/templates/init.vm
@@ -64,6 +64,10 @@
 	#set ($w3c_language_id = $localeUtil.toW3cLanguageId($theme_display.getLanguageId()))
 #end
 
+#if (!$is_setup_complete)
+	#set ($is_setup_complete = $theme_display.isImpersonated())
+#end
+
 #set ($time_zone = $user.getTimeZoneId())
 #set ($is_login_redirect_required = $portalUtil.isLoginRedirectRequired($request))
 #set ($is_signed_in = $theme_display.isSignedIn())

--- a/modules/apps/foundation/portal-template/portal-template-freemarker/src/main/resources/FTL_liferay.ftl
+++ b/modules/apps/foundation/portal-template/portal-template-freemarker/src/main/resources/FTL_liferay.ftl
@@ -11,9 +11,8 @@ LPS-30525.
 	css_main_file = ""
 	is_signed_in = false
 	js_main_file = ""
+	is_setup_complete = false
 />
-
-<#assign is_setup_complete = false />
 
 <#if user??>
 	<#assign is_setup_complete = user.isSetupComplete() />

--- a/modules/apps/foundation/portal-template/portal-template-freemarker/src/main/resources/FTL_liferay.ftl
+++ b/modules/apps/foundation/portal-template/portal-template-freemarker/src/main/resources/FTL_liferay.ftl
@@ -56,7 +56,7 @@ LPS-30525.
 </#macro>
 
 <#macro control_menu>
-	<#if themeDisplay.isImpersonated() || (is_setup_complete && is_signed_in)>
+	<#if is_setup_complete && is_signed_in>
 		<@liferay_product_navigation["control-menu"] />
 	</#if>
 </#macro>
@@ -138,7 +138,7 @@ ${languageUtil.format(locale, key, arguments)}</#macro>
 </#macro>
 
 <#macro user_personal_bar>
-	<#if themeDisplay.isImpersonated() || is_setup_complete || !is_signed_in>
+	<#if is_setup_complete || !is_signed_in>
 		<@liferay_portlet["runtime"]
 			portletProviderAction=portletProviderAction.VIEW
 			portletProviderClassName="com.liferay.admin.kernel.util.PortalUserPersonalBarApplicationType$UserPersonalBar"

--- a/modules/apps/foundation/portal-template/portal-template-freemarker/src/main/resources/FTL_liferay.ftl
+++ b/modules/apps/foundation/portal-template/portal-template-freemarker/src/main/resources/FTL_liferay.ftl
@@ -13,16 +13,20 @@ LPS-30525.
 	js_main_file = ""
 />
 
-<#if themeDisplay??>
-	<#assign css_main_file = htmlUtil.escape(portalUtil.getStaticResourceURL(request, "${themeDisplay.getPathThemeCss()}/main.css")) />
-	<#assign is_signed_in = themeDisplay.isSignedIn() />
-	<#assign js_main_file = htmlUtil.escape(portalUtil.getStaticResourceURL(request, "${themeDisplay.getPathThemeJavaScript()}/main.js")) />
-</#if>
-
 <#assign is_setup_complete = false />
 
 <#if user??>
 	<#assign is_setup_complete = user.isSetupComplete() />
+</#if>
+
+<#if themeDisplay??>
+	<#assign css_main_file = htmlUtil.escape(portalUtil.getStaticResourceURL(request, "${themeDisplay.getPathThemeCss()}/main.css")) />
+	<#assign is_signed_in = themeDisplay.isSignedIn() />
+	<#assign js_main_file = htmlUtil.escape(portalUtil.getStaticResourceURL(request, "${themeDisplay.getPathThemeJavaScript()}/main.js")) />
+
+	<#if !is_setup_complete>
+		<#assign is_setup_complete = themeDisplay.isImpersonated() />
+	</#if>
 </#if>
 
 <#function max x y>

--- a/modules/apps/foundation/portal-template/portal-template-velocity/src/main/resources/VM_liferay.vm
+++ b/modules/apps/foundation/portal-template/portal-template-velocity/src/main/resources/VM_liferay.vm
@@ -23,7 +23,7 @@
 #end
 
 #macro (control_menu)
-	#if ($themeDisplay.isImpersonated() || ($is_setup_complete && $is_signed_in))
+	#if ($is_setup_complete && $is_signed_in)
 		$theme.runtime("com.liferay.admin.kernel.util.PortalProductNavigationControlMenuApplicationType$ProductNavigationControlMenu", $portletProviderAction.VIEW)
 	#end
 #end
@@ -72,7 +72,7 @@ $languageUtil.format($locale, $lang_key, $arguments.toArray())#end
 #end
 
 #macro (user_personal_bar)
-	#if ($themeDisplay.isImpersonated() || $is_setup_complete || !$is_signed_in))
+	#if ($is_setup_complete || !$is_signed_in)
 		#set ($render_portlet_boundary = $request.getAttribute("RENDER_PORTLET_BOUNDARY"))
 
 		$request.setAttribute("RENDER_PORTLET_BOUNDARY", false)

--- a/modules/apps/foundation/portal-template/portal-template-velocity/src/main/resources/VM_liferay.vm
+++ b/modules/apps/foundation/portal-template/portal-template-velocity/src/main/resources/VM_liferay.vm
@@ -14,6 +14,10 @@
 	#set ($is_setup_complete = $user.isSetupComplete())
 #end
 
+#if (!$is_setup_complete)
+	#set ($is_setup_complete = $themeDisplay.isImpersonated())
+#end
+
 #macro (breadcrumbs $default_preferences)
 	$theme.runtime("com.liferay.portal.kernel.servlet.taglib.ui.BreadcrumbEntry", $portletProviderAction.VIEW, "", $!default_preferences)
 #end


### PR DESCRIPTION
Hey @jbalsas 

Originally I thought the variables set in `FTL_liferay.ftl` were available in ADTs/Web Content templates, but that doesn't appear to be true, which means we can take this approach. Doing it this way is backwards compatible in regards to the base themes as well. Let me know if you have any questions.