### PR TITLE
LPS-71562 Cancel on popups saves the modifications

### DIFF
--- a/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/js/main.js
+++ b/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/js/main.js
@@ -252,7 +252,11 @@ AUI.add(
 												}
 											);
 
-											instance._setContentLabels(id.replace(instance.ns('PORTLET_DATA') + '_', ''));
+											var portletId = id.replace(instance.ns('PORTLET_DATA') + '_', '');
+											instance._setContentLabels(portletId);
+
+											var contentNode = instance.byId('content_' + portletId);
+											instance._storeNodeInputStates(contentNode);
 										}
 									}
 								);

--- a/modules/apps/web-experience/staging/staging-processes-web/src/main/resources/META-INF/resources/js/main.js
+++ b/modules/apps/web-experience/staging/staging-processes-web/src/main/resources/META-INF/resources/js/main.js
@@ -19,6 +19,8 @@ AUI.add(
 
 		var STR_EMPTY = '';
 
+		var STR_HIDE = 'hide';
+
 		var defaultConfig = {
 			setter: '_setNode'
 		};
@@ -58,6 +60,8 @@ AUI.add(
 
 						instance._exportLAR = config.exportLAR;
 						instance._layoutsExportTreeOutput = instance.byId(config.pageTreeId + 'Output');
+
+						instance._nodeInputStates = [];
 
 						instance._initLabels();
 
@@ -325,6 +329,8 @@ AUI.add(
 
 															instance._setContentLabels(portletId);
 
+															instance._storeNodeInputStates(contentNode);
+
 															contentDialog.hide();
 														}
 													},
@@ -335,6 +341,8 @@ AUI.add(
 													on: {
 														click: function(event) {
 															event.domEvent.preventDefault();
+
+															instance._restoreNodeInputStates(contentNode);
 
 															contentDialog.hide();
 														}
@@ -348,6 +356,8 @@ AUI.add(
 								}
 							);
 
+							instance._storeNodeInputStates(contentNode);
+
 							contentNode.setData('contentDialog', contentDialog);
 						}
 
@@ -359,9 +369,9 @@ AUI.add(
 
 						var contentOptionsDialog = instance._contentOptionsDialog;
 
-						if (!contentOptionsDialog) {
-							var contentOptionsNode = instance.byId('contentOptions');
+						var contentOptionsNode = instance.byId('contentOptions');
 
+						if (!contentOptionsDialog) {
 							contentOptionsNode.show();
 
 							contentOptionsDialog = Liferay.Util.Window.getWindow(
@@ -382,6 +392,8 @@ AUI.add(
 
 															instance._setContentOptionsLabels();
 
+															instance._storeNodeInputStates(contentOptionsNode);
+
 															contentOptionsDialog.hide();
 														}
 													},
@@ -392,6 +404,8 @@ AUI.add(
 													on: {
 														click: function(event) {
 															event.domEvent.preventDefault();
+
+															instance._restoreNodeInputStates(contentOptionsNode);
 
 															contentOptionsDialog.hide();
 														}
@@ -404,6 +418,8 @@ AUI.add(
 									title: Liferay.Language.get('comments-and-ratings')
 								}
 							);
+
+							instance._storeNodeInputStates(contentOptionsNode);
 
 							instance._contentOptionsDialog = contentOptionsDialog;
 						}
@@ -782,6 +798,59 @@ AUI.add(
 						}
 					},
 
+					_restoreNodeCheckedState: function(node, state) {
+						var val = state.value;
+
+						if (val !== undefined) {
+							node.set('checked', val);
+						}
+					},
+
+					_restoreNodeHiddenState: function(node, state) {
+						var hiddenList = node.ancestorsByClassName(STR_HIDE);
+
+						hiddenList.each(
+							function(hiddenNode) {
+								hiddenNode.removeClass(STR_HIDE);
+							}
+						);
+
+						hiddenList = state.hiddenList;
+
+						if (hiddenList !== null) {
+							hiddenList.each(
+								function(node) {
+									node.addClass(STR_HIDE);
+								}
+							);
+						}
+					},
+
+					_restoreNodeInputStates: function(node) {
+						var instance = this;
+
+						var inputNodes = [];
+
+						var inputStates = instance._nodeInputStates;
+
+						if (node && node.getElementsByTagName) {
+							inputNodes = node.getElementsByTagName('input');
+						}
+
+						inputNodes.each(
+							function(node) {
+								var id = node.get('id');
+
+								var state = inputStates[id];
+
+								if (state !== undefined) {
+									instance._restoreNodeCheckedState(node, state);
+									instance._restoreNodeHiddenState(node, state);
+								}
+							}
+						);
+					},
+
 					_scheduleRenderProcess: function() {
 						var instance = this;
 
@@ -893,6 +962,35 @@ AUI.add(
 						}
 
 						return val;
+					},
+
+					_storeNodeInputStates: function(node) {
+						var instance = this;
+
+						var inputNodes = [];
+
+						var inputStates = instance._nodeInputStates;
+
+						if (node && node.getElementsByTagName) {
+							inputNodes = node.getElementsByTagName('input');
+						}
+
+						inputNodes.each(function(node) {
+							var hiddenList = node.ancestorsByClassName(STR_HIDE);
+
+							var id = node.get('id');
+
+							var val = node.get('checked');
+
+							if (hiddenList.size() === 0) {
+								hiddenList = null;
+							}
+
+							inputStates[id] = {
+								'value': val,
+								'hiddenList': hiddenList
+							};
+						});
 					},
 
 					_updateDateRange: function(event) {

--- a/modules/apps/web-experience/staging/staging-processes-web/src/main/resources/META-INF/resources/js/main.js
+++ b/modules/apps/web-experience/staging/staging-processes-web/src/main/resources/META-INF/resources/js/main.js
@@ -201,7 +201,11 @@ AUI.add(
 												}
 											);
 
-											instance._setContentLabels(id.replace(instance.ns('PORTLET_DATA') + '_', ''));
+											var portletId = id.replace(instance.ns('PORTLET_DATA') + '_', '');
+											instance._setContentLabels(portletId);
+
+											var contentNode = instance.byId('content_' + portletId);
+											instance._storeNodeInputStates(contentNode);
 										}
 									}
 								);


### PR DESCRIPTION
Hi Chema,

Cancel button did not work for pop-ups. I stored the state (checked and hidden) for the checkboxes in pup-ups and restored the states when clicking on Cancel. Storing/restoring only the checked state is not enough, because some clicks hides the children checkboxes and these should be displayed after clicking on cancel.

I tested manually, here are my detailed steps:
https://issues.liferay.com/browse/LPS-71562?focusedCommentId=1081123&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1081123
QA also tested this and it worked.

Could you review it?

Thank you in advance
Péter