### PR TITLE
LPS-74304 Add global build

### DIFF
--- a/modules/apps/foundation/frontend-js/frontend-js-web/build.gradle
+++ b/modules/apps/foundation/frontend-js/frontend-js-web/build.gradle
@@ -1,3 +1,4 @@
+import com.liferay.gradle.plugins.js.transpiler.TranspileJSTask
 import com.liferay.gradle.util.FileUtil
 import com.liferay.gradle.util.copy.StripPathSegmentsAction
 
@@ -16,6 +17,7 @@ task buildLiferayAMDLoader(type: Copy)
 task buildLodash(type: Copy)
 task buildSvg4everybody(type: Copy)
 task testJS
+task transpileJSGlobal(type: TranspileJSTask)
 
 String jqueryPluginsFormVersion = "3.51"
 String jQueryVersion = "2.1.4"
@@ -131,6 +133,7 @@ classes {
 	dependsOn buildLiferayAMDLoader
 	dependsOn buildLodash
 	dependsOn buildSvg4everybody
+	dependsOn transpileJSGlobal
 }
 
 clean {
@@ -156,4 +159,15 @@ dependencies {
 
 testJS {
 	dependsOn gulpTest
+}
+
+transpileJSGlobal {
+	dependsOn npmInstall
+	bundleFileName = "liferay/global.js"
+	globalName = "metal"
+	modules = "globals"
+	sourceDir = "src/main/resources/META-INF/resources"
+	soySkipMetalGeneration = true
+	srcIncludes = "liferay/global.js"
+	workingDir = "${sourceSets.main.output.resourcesDir}/META-INF/resources"
 }

--- a/modules/apps/foundation/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.js
+++ b/modules/apps/foundation/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.js
@@ -1,0 +1,1 @@
+import {EventEmitter} from 'metal-events';

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -1454,6 +1454,12 @@
         lexicon/bootstrap.js,\
         \
         #
+        # Liferay globals
+        #
+        \
+        liferay/global.js,\
+        \
+        #
         # Loader core
         #
         \


### PR DESCRIPTION
Hey @jbalsas @brunobasto

Not intending this to be merged in it's current state, just wanted to see what you guys thought about having a global build like this.

Eventually this `global.js` file would be used to replace AUI functionality in various files such as turning the global `Liferay` object into an [event emitter](https://github.com/liferay/liferay-portal/blob/master/modules/apps/foundation/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/events.js#L48-L54).

The only thing we'd have to watch out for is adding too many imports to this file, we shouldn't let it get too large.