### PR TITLE
LRDOCS-4111 JSdoc Ant task

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -782,15 +782,9 @@ message.
 
 	<target name="jsdoc">
 		<property name="jsdoc.dest.dir" value="${doc.dir}/jsdoc" />
+		<property name="jsdoc.read.dir" value="./" />
 
 		<remake-dir dir="${jsdoc.dest.dir}" />
-		<antcall target="jsdoc-cmd">
-			<param name="jsdoc.read.dir" value=".\modules\apps\" />
-			<param name="jsdoc.dest.dir" value="${jsdoc.dest.dir}" />
-		</antcall>
-	</target>
-	
-	<target name="jsdoc-cmd">
 		<execute>
 			jsdoc ${jsdoc.read.dir} -c ./conf.json -r -d ./api/jsdoc
 		</execute>

--- a/build.xml
+++ b/build.xml
@@ -623,6 +623,7 @@ message.
 		<antcall target="dtddoc" />
 		<antcall target="javadoc" />
 		<antcall target="propertiesdoc" />
+		<antcall target="jsdoc" />
 		<ant dir="util-taglib" inheritAll="false" target="taglibdoc" />
 	</target>
 
@@ -777,6 +778,22 @@ message.
 
 			<tag description="{$generated.description}" name="generated" />
 		</javadoc>
+	</target>
+
+	<target name="jsdoc">
+		<property name="jsdoc.dest.dir" value="${doc.dir}/jsdoc" />
+
+		<remake-dir dir="${jsdoc.dest.dir}" />
+		<antcall target="jsdoc-cmd">
+			<param name="jsdoc.read.dir" value=".\modules\apps\" />
+			<param name="jsdoc.dest.dir" value="${jsdoc.dest.dir}" />
+		</antcall>
+	</target>
+	
+	<target name="jsdoc-cmd">
+		<execute>
+			jsdoc ${jsdoc.read.dir} -c ./conf.json -r -d ./api/jsdoc
+		</execute>
 	</target>
 
 	<target name="prepare-generated-files">

--- a/conf.json
+++ b/conf.json
@@ -1,6 +1,6 @@
 {
     "plugins": [],
-    "recurseDepth": 10,
+    "recurseDepth": 20,
     "source": {
         "includePattern": ".+\\.es.js(doc|x)?$",
         "excludePattern": "(^|\\/|\\\\)_"

--- a/conf.json
+++ b/conf.json
@@ -1,0 +1,17 @@
+{
+    "plugins": [],
+    "recurseDepth": 10,
+    "source": {
+        "includePattern": ".+\\.es.js(doc|x)?$",
+        "excludePattern": "(^|\\/|\\\\)_"
+    },
+    "sourceType": "module",
+    "tags": {
+        "allowUnknownTags": true,
+        "dictionaries": ["jsdoc","closure"]
+    },
+    "templates": {
+        "cleverLinks": false,
+        "monospaceLinks": false
+    }
+}

--- a/modules/apps/web-experience/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/js/ToggleDisableInputs.es.js
+++ b/modules/apps/web-experience/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/js/ToggleDisableInputs.es.js
@@ -46,6 +46,8 @@ ToggleDisableInputs.STATE = {
 	/**
 	 * Switch state
 	 * @type {Boolean}
+	 * @memberof! ToggleDisableInputs#
+	 * @instance ToggleDisableInputs.STATE.checked
 	 */
 	checked: {
 		validator: core.isBoolean,
@@ -55,6 +57,8 @@ ToggleDisableInputs.STATE = {
 	/**
 	 * Flag to specify the logic for disabling inputs based on switch state
 	 * @type {Boolean}
+	 * @memberof! ToggleDisableInputs#
+	 * @instance ToggleDisableInputs.STATE.disableOnChecked
 	 */
 	disableOnChecked: {
 		validator: core.isBoolean,
@@ -64,6 +68,8 @@ ToggleDisableInputs.STATE = {
 	/**
 	 * CSS Selector for the inputs to enable/disable
 	 * @type {String}
+	 * @memberof! ToggleDisableInputs#
+	 * @instance ToggleDisableInputs.STATE.inputSelector
 	 */
 	inputSelector: {
 		validator: core.isString
@@ -72,6 +78,8 @@ ToggleDisableInputs.STATE = {
 	/**
 	 * Label of the switch
 	 * @type {String}
+	 * @memberof! ToggleDisableInputs#
+	 * @instance ToggleDisableInputs.STATE.label
 	 */
 	label: {
 		validator: core.isString


### PR DESCRIPTION
@jbalsas Just install jsdoc and run `ant jsdoc` from the liferay-portal root folder to generate the docs. They'll be in the `api\jsdoc` folder. I've also added extra jsdoc to `ToggleDisableInputs.es.js` to show how we can have JSdoc for STATE properties. Let me know if that's something we want to do. Please let me know if this is covering the proper modules. Thanks!