### PR TITLE
Provide API similar to Liferay.provide for the amd loader

### DIFF
--- a/modules/apps/foundation/frontend-js/frontend-js-web/bnd.bnd
+++ b/modules/apps/foundation/frontend-js/frontend-js-web/bnd.bnd
@@ -143,6 +143,7 @@ Liferay-Top-Head-JS-Resources:\
 	/liferay/events.js,\
 	/liferay/language.js,\
 	/liferay/liferay.js,\
+	/liferay/lazy.js,\
 	/liferay/util.js,\
 	\
 	/liferay/portal.js,\

--- a/modules/apps/foundation/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/lazy.js
+++ b/modules/apps/foundation/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/lazy.js
@@ -1,0 +1,49 @@
+(function(_, Liferay) {
+	Liferay.lazy = function() {
+		var failureCallback;
+		var modules;
+		var successCallback;
+
+		if (_.isArray(arguments[0])) {
+			modules = arguments[0];
+
+			successCallback = _.isFunction(arguments[1]) ? arguments[1] : null;
+			failureCallback = _.isFunction(arguments[2]) ? arguments[2] : null;
+		}
+		else {
+			modules = [];
+
+			for (var i = 0; i < arguments.length; ++i) {
+				if (_.isString(arguments[i])) {
+					modules[i] = arguments[i];
+				}
+				else if (_.isFunction(arguments[i])) {
+					successCallback = arguments[i];
+					failureCallback = _.isFunction(arguments[++i]) ? arguments[i] : null;
+
+					break;
+				}
+			}
+		}
+
+		return function() {
+			var args = [];
+
+			for (var i = 0; i < arguments.length; ++i) {
+				args.push(arguments[i]);
+			}
+
+			Liferay.Loader.require(
+				modules,
+				function() {
+					for (var i = 0; i < arguments.length; ++i) {
+						args.splice(i, 0, arguments[i]);
+					}
+
+					successCallback.apply(successCallback, args);
+				},
+				failureCallback
+			);
+		};
+	}
+})(AUI._, Liferay);


### PR DESCRIPTION
Hey @jbalsas,

Here is the Liferay.lazy method implemented in Portal. Since we don’t currently have a task for transpiling es6 to a non amd wrapped component, it’s just written in common js since we need this globally available immediately just like Liferay.provide or our other global utilities.

Obviously I’d like some tests, just not sure what we can accomplish here.