### PR TITLE
LPS-77224 Apply new NavigationBar pattern to roles-selector-web

### DIFF
--- a/modules/apps/foundation/roles/roles-selector-web/build.gradle
+++ b/modules/apps/foundation/roles/roles-selector-web/build.gradle
@@ -1,6 +1,11 @@
+sourceCompatibility = "1.8"
+targetCompatibility = "1.8"
+
 dependencies {
 	provided group: "com.liferay", name: "com.liferay.frontend.taglib", version: "2.0.0"
+	provided group: "com.liferay", name: "com.liferay.frontend.taglib.soy", version: "1.0.0"
 	provided group: "com.liferay", name: "com.liferay.petra.lang", version: "1.0.0"
+	provided group: "com.liferay", name: "com.liferay.petra.string", version: "1.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "2.0.0"
@@ -8,4 +13,5 @@ dependencies {
 	provided group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
 	provided group: "javax.servlet.jsp", name: "javax.servlet.jsp-api", version: "2.3.1"
 	provided group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	provided project(":apps:foundation:frontend-taglib:frontend-taglib-clay")
 }

--- a/modules/apps/foundation/roles/roles-selector-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/foundation/roles/roles-selector-web/src/main/resources/META-INF/resources/init.jsp
@@ -19,12 +19,15 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@
 taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 
 <%@ page import="com.liferay.exportimport.kernel.staging.StagingUtil" %><%@
+page import="com.liferay.frontend.taglib.clay.servlet.taglib.util.JSPNavigationItemList" %><%@
+page import="com.liferay.petra.string.StringPool" %><%@
 page import="com.liferay.portal.kernel.dao.orm.QueryUtil" %><%@
 page import="com.liferay.portal.kernel.dao.search.SearchContainer" %><%@
 page import="com.liferay.portal.kernel.exception.NoSuchRoleException" %><%@

--- a/modules/apps/foundation/roles/roles-selector-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/foundation/roles/roles-selector-web/src/main/resources/META-INF/resources/view.jsp
@@ -85,34 +85,37 @@ request.setAttribute("edit_roles.jsp-roleType", roleType);
 request.setAttribute("edit_roles.jsp-portletURL", portletURL);
 %>
 
-<aui:nav-bar cssClass="collapse-basic-search" markupView="lexicon">
-	<aui:nav cssClass="navbar-nav">
-		<c:choose>
-			<c:when test="<%= role == null %>">
-				<aui:nav-item label="roles" selected="<%= true %>" />
-			</c:when>
-			<c:otherwise>
+<clay:navigation-bar
+	items='<%=
+		new JSPNavigationItemList(pageContext) {
+			{
+				if (role == null) {
+					add(
+						navigationItem -> {
+							navigationItem.setActive(true);
+							navigationItem.setHref(StringPool.BLANK);
+							navigationItem.setLabel(LanguageUtil.get(request, "roles"));
+						});
+				}
+				else {
+					add(
+						navigationItem -> {
+							navigationItem.setActive(tabs1.equals("current"));
+							navigationItem.setHref(portletURL, "tabs1", "current");
+							navigationItem.setLabel(LanguageUtil.get(request, "current"));
+						});
 
-				<%
-				portletURL.setParameter("tabs1", "current");
-				%>
-
-				<aui:nav-item href="<%= portletURL.toString() %>" label="current" selected='<%= tabs1.equals("current") %>' />
-
-				<%
-				portletURL.setParameter("tabs1", "available");
-				%>
-
-				<aui:nav-item href="<%= portletURL.toString() %>" label="available" selected='<%= tabs1.equals("available") %>' />
-
-				<%
-				portletURL.setParameter("tabs1", tabs1);
-				%>
-
-			</c:otherwise>
-		</c:choose>
-	</aui:nav>
-</aui:nav-bar>
+					add(
+						navigationItem -> {
+							navigationItem.setActive(tabs1.equals("available"));
+							navigationItem.setHref(portletURL, "tabs1", "available");
+							navigationItem.setLabel(LanguageUtil.get(request, "available"));
+						});
+				}
+			}
+		}
+	%>'
+/>
 
 <liferay-frontend:management-bar>
 	<liferay-frontend:management-bar-filters>

--- a/modules/apps/foundation/roles/roles-selector-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/foundation/roles/roles-selector-web/src/main/resources/META-INF/resources/view.jsp
@@ -112,13 +112,17 @@ request.setAttribute("edit_roles.jsp-portletURL", portletURL);
 			</c:otherwise>
 		</c:choose>
 	</aui:nav>
-
-	<aui:nav-bar-search>
-		<aui:form action="<%= portletURL.toString() %>" name="searchFm">
-			<liferay-ui:input-search autoFocus="<%= windowState.equals(WindowState.MAXIMIZED) %>" markupView="lexicon" placeholder='<%= LanguageUtil.get(request, "keywords") %>' />
-		</aui:form>
-	</aui:nav-bar-search>
 </aui:nav-bar>
+
+<liferay-frontend:management-bar>
+	<liferay-frontend:management-bar-filters>
+		<li>
+			<aui:form action="<%= portletURL.toString() %>" name="searchFm">
+				<liferay-ui:input-search autoFocus="<%= windowState.equals(WindowState.MAXIMIZED) %>" markupView="lexicon" placeholder='<%= LanguageUtil.get(request, "keywords") %>' />
+			</aui:form>
+		</li>
+	</liferay-frontend:management-bar-filters>
+</liferay-frontend:management-bar>
 
 <aui:form action="<%= portletURL.toString() %>" method="post" name="fm">
 	<aui:input name="tabs1" type="hidden" value="<%= tabs1 %>" />


### PR DESCRIPTION
Hi Chema,

I got some styling issues after applying the new navigation bar pattern to the roles-selector-web: the management bar is overlapped with the dialog body. After talking to Patrick, he thinks it might be due to the styling of the `roles-selector-body` css selector. Can you take a look at the issue? Thanks!

*To navigate to the roles selector modal:
1. Add an organization
2. Go to the Organizations tab in the Users and Organizations portlet
3. Click on an organization's action menu and select `Assign Organization Roles`


**_Before new pattern applied_**

<img width="1354" alt="screen shot 2018-03-01 at 11 04 12 am" src="https://user-images.githubusercontent.com/5168351/36866642-b7ddae5e-1d47-11e8-82ce-231e8939ecfb.png">
<img width="1354" alt="screen shot 2018-03-01 at 11 04 31 am" src="https://user-images.githubusercontent.com/5168351/36866643-b7fd4020-1d47-11e8-8cb5-80e00870c374.png">

**_After new pattern applied_**

<img width="1349" alt="screen shot 2018-03-01 at 11 05 43 am" src="https://user-images.githubusercontent.com/5168351/36866644-bbc57a42-1d47-11e8-98a8-03d864486875.png">
<img width="1350" alt="screen shot 2018-03-01 at 11 06 00 am" src="https://user-images.githubusercontent.com/5168351/36866646-bbdee248-1d47-11e8-8fe5-ec2a5dfdaa7a.png">

/cc @drewbrokke
