### PR TITLE
LPS-83052 Fix ModuleNameUtil to fit the changes we are doing to semantics

### DIFF
--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender-api/src/main/java/com/liferay/frontend/js/loader/modules/extender/npm/ModuleNameUtil.java
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender-api/src/main/java/com/liferay/frontend/js/loader/modules/extender/npm/ModuleNameUtil.java
@@ -119,7 +119,6 @@ public class ModuleNameUtil {
 	 * @param  moduleName the module's name
 	 * @return the package name or <code>null</code> if the module name is a
 	 *         reserved or local one
-	 * @review
 	 */
 	public static String getPackageName(String moduleName) {
 		if (isLocalModuleName(moduleName)) {
@@ -208,13 +207,15 @@ public class ModuleNameUtil {
 	 * @return the module's name
 	 */
 	public static String toModuleName(String fileName) {
-		if (isLocalModuleName(fileName)) {
-			fileName = fileName.substring(2);
-		}
-
 		int i = fileName.lastIndexOf(CharPool.PERIOD);
 
 		if (i == -1) {
+			return fileName;
+		}
+
+		String extension = fileName.substring(i);
+
+		if (!extension.equals(".js")) {
 			return fileName;
 		}
 

--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender-api/src/main/java/com/liferay/frontend/js/loader/modules/extender/npm/ModuleNameUtil.java
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender-api/src/main/java/com/liferay/frontend/js/loader/modules/extender/npm/ModuleNameUtil.java
@@ -17,6 +17,7 @@ package com.liferay.frontend.js.loader.modules.extender.npm;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.FileUtil;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -91,6 +92,7 @@ public class ModuleNameUtil {
 	 * @param  jsPackage the NPM package
 	 * @param  moduleName the module's name
 	 * @return the module ID
+	 * @review
 	 */
 	public static String getModuleId(JSPackage jsPackage, String moduleName) {
 		StringBundler sb = new StringBundler(3);
@@ -207,13 +209,7 @@ public class ModuleNameUtil {
 	 * @return the module's name
 	 */
 	public static String toModuleName(String fileName) {
-		int i = fileName.lastIndexOf(CharPool.PERIOD);
-
-		if (i == -1) {
-			return fileName;
-		}
-
-		String extension = fileName.substring(i);
+		String extension = FileUtil.getExtension(fileName);
 
 		if (!extension.equals(".js")) {
 			return fileName;

--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender-api/src/test/java/com/liferay/frontend/js/loader/modules/extender/npm/ModuleNameUtilTest.java
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender-api/src/test/java/com/liferay/frontend/js/loader/modules/extender/npm/ModuleNameUtilTest.java
@@ -83,12 +83,31 @@ public class ModuleNameUtilTest {
 		Assert.assertEquals(
 			"a-package/a-folder/a-module",
 			ModuleNameUtil.toModuleName("a-package/a-folder/a-module.js"));
+	}
+
+	@Test
+	public void testToModuleNameWithNonJsExtensions() {
+		Assert.assertEquals(
+			"a-module.es", ModuleNameUtil.toModuleName("a-module.es"));
 
 		Assert.assertEquals(
-			"a-module", ModuleNameUtil.toModuleName("./a-module"));
+			"a-folder/a-module.es",
+			ModuleNameUtil.toModuleName("a-folder/a-module.es"));
+	}
+
+	@Test
+	public void testToModuleNameWithRelativePaths() {
+		Assert.assertEquals(
+			"./a-module", ModuleNameUtil.toModuleName("./a-module"));
 
 		Assert.assertEquals(
-			"a-module", ModuleNameUtil.toModuleName("./a-module.js"));
+			"./a-module", ModuleNameUtil.toModuleName("./a-module.js"));
+
+		Assert.assertEquals(
+			"../a-module", ModuleNameUtil.toModuleName("../a-module"));
+
+		Assert.assertEquals(
+			"../a-module", ModuleNameUtil.toModuleName("../a-module.js"));
 	}
 
 }

--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/npm/builtin/BaseBuiltInJSModuleServlet.java
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/npm/builtin/BaseBuiltInJSModuleServlet.java
@@ -15,6 +15,7 @@
 package com.liferay.frontend.js.loader.modules.extender.internal.npm.builtin;
 
 import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.MimeTypes;
 import com.liferay.portal.kernel.util.StreamUtil;
 
@@ -86,10 +87,12 @@ public abstract class BaseBuiltInJSModuleServlet extends HttpServlet {
 	private void _setContentType(HttpServletResponse response, URL url) {
 		String file = url.getFile();
 
-		if (file.endsWith(".js")) {
+		String extension = FileUtil.getExtension(file);
+
+		if (extension.equals(".js")) {
 			response.setContentType(ContentTypes.TEXT_JAVASCRIPT_UTF8);
 		}
-		else if (file.endsWith(".map")) {
+		else if (extension.equals(".map")) {
 			response.setContentType(ContentTypes.APPLICATION_JSON);
 		}
 		else {

--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/npm/builtin/BuiltInJSModuleServlet.java
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/npm/builtin/BuiltInJSModuleServlet.java
@@ -14,8 +14,13 @@
 
 package com.liferay.frontend.js.loader.modules.extender.internal.npm.builtin;
 
-import com.liferay.frontend.js.loader.modules.extender.npm.JSModule;
+import com.liferay.frontend.js.loader.modules.extender.npm.JSPackage;
+import com.liferay.frontend.js.loader.modules.extender.npm.ModuleNameUtil;
 import com.liferay.frontend.js.loader.modules.extender.npm.NPMRegistry;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.MimeTypes;
+
+import java.net.URL;
 
 import javax.servlet.Servlet;
 
@@ -37,11 +42,42 @@ import org.osgi.service.component.annotations.Reference;
 public class BuiltInJSModuleServlet extends BaseBuiltInJSModuleServlet {
 
 	@Override
-	protected JSModule getJSModule(String moduleName) {
-		return _npmRegistry.getJSModule(moduleName);
+	protected MimeTypes getMimeTypes() {
+		return _mimeTypes;
+	}
+
+	@Override
+	protected URL getURL(String pathInfo) {
+		String identifier = pathInfo.substring(1);
+
+		int i = identifier.indexOf(StringPool.SLASH);
+
+		if (i == -1) {
+			return null;
+		}
+
+		String bundleId = identifier.substring(0, i);
+
+		identifier = identifier.substring(i + 1);
+
+		String packageName = ModuleNameUtil.getPackageName(identifier);
+
+		JSPackage jsPackage = _npmRegistry.getJSPackage(
+			bundleId + StringPool.SLASH + packageName);
+
+		if (jsPackage == null) {
+			return null;
+		}
+
+		String packagePath = ModuleNameUtil.getPackagePath(identifier);
+
+		return jsPackage.getResourceURL(packagePath);
 	}
 
 	private static final long serialVersionUID = -8753225208295935344L;
+
+	@Reference
+	private MimeTypes _mimeTypes;
 
 	@Reference
 	private NPMRegistry _npmRegistry;

--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/npm/builtin/BuiltInJSResolvedModuleServlet.java
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/npm/builtin/BuiltInJSResolvedModuleServlet.java
@@ -53,9 +53,9 @@ public class BuiltInJSResolvedModuleServlet extends BaseBuiltInJSModuleServlet {
 	protected URL getURL(String pathInfo) {
 		String identifier = pathInfo.substring(1);
 
-		String resolvedPackageId = ModuleNameUtil.getPackageName(identifier);
+		String resolvedJSPackageId = ModuleNameUtil.getPackageName(identifier);
 
-		JSPackage jsPackage = _getResolvedJSPackage(resolvedPackageId);
+		JSPackage jsPackage = _getResolvedJSPackage(resolvedJSPackageId);
 
 		if (jsPackage == null) {
 			return null;
@@ -66,9 +66,9 @@ public class BuiltInJSResolvedModuleServlet extends BaseBuiltInJSModuleServlet {
 		return jsPackage.getResourceURL(packagePath);
 	}
 
-	private JSPackage _getResolvedJSPackage(String resolvedPackageId) {
+	private JSPackage _getResolvedJSPackage(String resolvedJSPackageId) {
 		String packageId = _resolvedPackageIdentifiersCache.get(
-			resolvedPackageId);
+			resolvedJSPackageId);
 
 		if (packageId != null) {
 			JSPackage jsPackage = _npmRegistry.getJSPackage(packageId);
@@ -77,16 +77,16 @@ public class BuiltInJSResolvedModuleServlet extends BaseBuiltInJSModuleServlet {
 				return jsPackage;
 			}
 
-			_resolvedPackageIdentifiersCache.remove(resolvedPackageId);
+			_resolvedPackageIdentifiersCache.remove(resolvedJSPackageId);
 		}
 
 		Collection<JSPackage> resolvedJSPackages =
 			_npmRegistry.getResolvedJSPackages();
 
 		for (JSPackage resolvedJSPackage : resolvedJSPackages) {
-			if (resolvedPackageId.equals(resolvedJSPackage.getResolvedId())) {
+			if (resolvedJSPackageId.equals(resolvedJSPackage.getResolvedId())) {
 				_resolvedPackageIdentifiersCache.put(
-					resolvedPackageId, resolvedJSPackage.getId());
+					resolvedJSPackageId, resolvedJSPackage.getId());
 
 				return resolvedJSPackage;
 			}


### PR DESCRIPTION
This PR uses an LRU cache in the servlet side to avoid introducing breaking changes in the npm API. This is to ease backport but, at the same time, not incurring in big performance penalties.

The cache size is bound to a maximum length equal to the number of resolved JS packages. Because the number of resolved JS packages may grow or shrink with time, the cache will adapt to those changes automatically by enlarging the cache size or by removing stale cache entries.
 
In a future PR we will add a new method in `NPMRegistry` to be able to directly lookup resolved packages in the inner map that `NPMRegistry` holds and thus be able to avoid the LRU cache.