### PR TITLE
LPS-88376 Cannot add a tag because another tag with the same prefix is autoselected

### DIFF
--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_tags_selector/js/asset_taglib_tags_selector.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_tags_selector/js/asset_taglib_tags_selector.js
@@ -60,6 +60,10 @@ AUI.add(
 						value: true
 					},
 
+					autoHighlight: {
+						value: false
+					},
+
 					dataSource: {
 						valueFn: function() {
 							var instance = this;


### PR DESCRIPTION
Hey @jbalsas 

Could you please review this pull request?

I have set the `autoHighlight` attribute (inherited from `aui-autocomplete-deprecated`) to **false**, to prevent tags for being auto-selected.

Thank you and best regards,
István