### PR TITLE
[POC] Integrate Senna.js with external Routing Library (React Router/Reach Router)

### DIFF
--- a/modules/apps/frontend-js/frontend-js-spa-web/package-lock.json
+++ b/modules/apps/frontend-js/frontend-js-spa-web/package-lock.json
@@ -4302,6 +4302,18 @@
 				}
 			}
 		},
+		"history": {
+			"version": "4.7.2",
+			"resolved": "https://registry.npmjs.org/history/-/history-4.7.2.tgz",
+			"integrity": "sha512-1zkBRWW6XweO0NBcjiphtVJVsIQ+SXF29z9DVkceeaSLVMFXHool+fdCZD4spDCfZJCILPILc3bm7Bc+HRi0nA==",
+			"requires": {
+				"invariant": "2.2.4",
+				"loose-envify": "1.4.0",
+				"resolve-pathname": "2.2.0",
+				"value-equal": "0.4.0",
+				"warning": "3.0.0"
+			}
+		},
 		"home-or-tmp": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
@@ -4572,7 +4584,6 @@
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
 			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-			"dev": true,
 			"requires": {
 				"loose-envify": "1.4.0"
 			}
@@ -4973,8 +4984,7 @@
 		"js-tokens": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-			"dev": true
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
 		},
 		"js-yaml": {
 			"version": "3.12.0",
@@ -5484,7 +5494,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
 			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-			"dev": true,
 			"requires": {
 				"js-tokens": "3.0.2"
 			}
@@ -7337,6 +7346,11 @@
 			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
 			"dev": true
 		},
+		"resolve-pathname": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-2.2.0.tgz",
+			"integrity": "sha512-bAFz9ld18RzJfddgrO2e/0S2O81710++chRMUxHjXOYKF6jTAMrUNZrEZ1PvV0zlhfjidm08iRPdTLPno1FuRg=="
+		},
 		"resolve-url": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
@@ -8716,6 +8730,11 @@
 				"spdx-expression-parse": "3.0.0"
 			}
 		},
+		"value-equal": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/value-equal/-/value-equal-0.4.0.tgz",
+			"integrity": "sha512-x+cYdNnaA3CxvMaTX0INdTCN8m8aF2uY9BvEqmxuYp8bL09cs/kWVQPVGcA35fMktdOsP69IgU7wFj/61dJHEw=="
+		},
 		"verror": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
@@ -8752,6 +8771,14 @@
 			"dev": true,
 			"requires": {
 				"unist-util-stringify-position": "1.1.2"
+			}
+		},
+		"warning": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
+			"integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+			"requires": {
+				"loose-envify": "1.4.0"
 			}
 		},
 		"webidl-conversions": {

--- a/modules/apps/frontend-js/frontend-js-spa-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-spa-web/package.json
@@ -11,6 +11,7 @@
 		}
 	},
 	"dependencies": {
+		"history": "^4.7.2",
 		"metal": "^2.4.7",
 		"metal-dom": "^2.4.7",
 		"metal-uri": "^2.0.2",

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/init.es.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/init.es.js
@@ -11,6 +11,9 @@ import ActionURLScreen from './screen/ActionURLScreen.es';
 import App from './app/App.es';
 import RenderURLScreen from './screen/RenderURLScreen.es';
 
+import ReachRouterHistory from './routers/ReachRouter.es';
+import ReactRouterHistory from './routers/ReactRouter.es';
+
 /**
  * Initializes a Senna App with routes that match both ActionURLs and RenderURLs.
  * It also overrides Liferay's default Liferay.Util.submitForm to makes sure
@@ -97,6 +100,15 @@ let initSPA = function() {
 	};
 
 	Liferay.initComponentCache();
+
+	// Layer to expose the history manipulation APIs of the compatible
+	// route libraries with integration with Senna.js.
+	// WARNING:  API is unstable and can be modified at any time.
+
+	Liferay.SPA.unstable_history = {
+		ReachRouter: ReachRouterHistory(app),
+		ReactRouter: ReactRouterHistory(app)
+	};
 
 	Liferay.SPA.app = app;
 	Liferay.SPA.version = version;

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/routers/ReachRouter.es.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/routers/ReachRouter.es.js
@@ -1,0 +1,59 @@
+'use strict';
+
+/**
+ * The Reach Router provides a low-level API to create a
+ * representative window.history API. This layer is made over
+ * the window.history with integration with Senna.js.
+ *
+ * @example
+ * const history = createHistory(Liferay.SPA.unstable_history.ReachRouter)
+ * <LocationProvider history={history}></LocationProvider>
+ */
+
+const History = (sennaInstance) => {
+	const updateHistory = (state, uri) => {
+		const newState = Object.assign(
+			state,
+			{
+				origin: 'space',
+				path: uri,
+				scrollLeft: sennaInstance.popstateScrollLeft,
+				scrollTop: sennaInstance.popstateScrollTop
+			}
+		);
+
+		sennaInstance.setOriginActive(true);
+		sennaInstance.updateHistory_(null, uri, newState, false);
+	};
+
+	return {
+		addEventListener(name, fn) {
+			window.addEventListener(...arguments);
+		},
+		get location() {
+			return window.location;
+		},
+		removeEventListener(name, fn) {
+			window.removeEventListener(...arguments);
+		},
+		history: {
+			get entries() {
+				return window.history.entries;
+			},
+			get index() {
+				return window.history.index;
+			},
+			pushState(state, _, uri) {
+				updateHistory(state, uri);
+			},
+			replaceState(state, _, uri) {
+				updateHistory(state, uri);
+			},
+			get state() {
+				return window.history.state;
+			}
+		}
+	};
+};
+
+export default History;

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/routers/ReactRouter.es.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/routers/ReactRouter.es.js
@@ -1,0 +1,61 @@
+'use strict';
+
+import {createBrowserHistory} from 'history';
+
+/**
+ * The React Router offers a low-level API for manipulating history.
+ * This is a layer above the history of the React Router with
+ * integration with Senna.js.
+ *
+ * @example
+ * <Router history={Liferay.SPA.unstable_history.ReactRouter}></Router>
+ */
+
+const History = (sennaInstance) => {
+	const history = createBrowserHistory();
+
+	const updateState = (path, state) => {
+		const newPath = typeof path === 'object' ?
+			(path.pathname || '') + (path.search || '') :
+			path;
+		const newState = typeof state === 'object' ? state : {};
+
+		sennaInstance.setOriginActive(true);
+
+		return Object.assign(
+			newState,
+			{
+				origin: 'space',
+				path: newPath,
+				scrollLeft: sennaInstance.popstateScrollLeft,
+				scrollTop: sennaInstance.popstateScrollTop
+			}
+		);
+	};
+
+	const push = (path, state) => {
+		const newState = updateState(path, state);
+		history.push(path, newState);
+	};
+
+	const replace = (path, state) => {
+		const newState = updateState(path, state);
+		history.replace(path, newState);
+	};
+
+	return {
+		action: history.action,
+		block: history.block,
+		createHref: history.createHref,
+		go: history.go,
+		goBack: history.goBack,
+		goForward: history.goForward,
+		length: history.length,
+		listen: history.listen,
+		location: history.location,
+		push,
+		replace
+	};
+};
+
+export default History;


### PR DESCRIPTION
hey @jbalsas,

This is a small POC for integrating Senna.js with other route libraries like the [React Router](https://reacttraining.com/react-router/web/guides/quick-start) and [Reach Router](https://reach.tech/router), so that this works needs some modifications in Senna.js, I made some of them in my branch https://github.com/matuzalemsteles/senna.js/commit/7964c04673cfff0adeae12cb53efd4614fd6daa7.

I created a demo portlet, you can see here https://github.com/matuzalemsteles/portlet-react-senna.

### TL;DR

The integration consists of creating a custom API history for each lib of route, both libs have the possibility that we can create this layer to manipulate `window.history`, in this way we manipulate the instance of Senna.js to say when to ignore or do not ignore. With this approach maybe we can also create integrations with Angular and Vue if both enable.

However, anyone who uses has to make sure to add `data-senna-off` to the `<Link />` components. Maybe we can add some way for Senna to know that the portlet is using a custom route to not add the click listeners inside the portlet.

One of the challenges is paths, some parts of the portal use the query to tell which portlet to render and which screen to render... This is a bit challenging because libs do not render the component when a query changes, so you have to do the your own query analysis to render the route (I did something simple with this in the demo).

The main integration of this is to ensure that navigation is done between pages navigated with Senna.js and the route libs.

- Should return to the previous page that was navigated by a lib of route
- Should go to the next page that was navigated by a lib of route
- Should go and return to the page navigated by Senna.js