### PR TITLE
LPS-94477 available_languages.jsp should be minified

### DIFF
--- a/portal-web/docroot/WEB-INF/liferay-web.xml
+++ b/portal-web/docroot/WEB-INF/liferay-web.xml
@@ -22,7 +22,7 @@
 		<filter-class>com.liferay.portal.servlet.filters.aggregate.AggregateFilter</filter-class>
 		<init-param>
 			<param-name>url-regex-pattern</param-name>
-			<param-value>.+/(aui_lang|barebone|css|everything|main)\.jsp</param-value>
+			<param-value>.+/(aui_lang|available_languages|barebone|css|everything|main)\.jsp</param-value>
 		</init-param>
 	</filter>
 	<filter>


### PR DESCRIPTION
In production (ie. when "javascript.fast.load" is true) this file should be served minified.

Sending this to you to sanity check:

- My understanding is that this available_languages.jsp returns content that [varies according to the locale of the request](https://github.com/liferay/liferay-portal/blob/6d452c184a47e690ccfc994f07872d8f024f6871/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/available_languages.jsp#L42).
- The generated content is cached in [a file](https://github.com/liferay/liferay-portal/blob/6d452c184a47e690ccfc994f07872d8f024f6871/portal-impl/src/com/liferay/portal/servlet/filters/aggregate/AggregateFilter.java#L394) named using the [`CacheFileNameGenerator` class](https://github.com/liferay/liferay-portal/blob/6d452c184a47e690ccfc994f07872d8f024f6871/portal-impl/src/com/liferay/portal/servlet/filters/util/CacheFileNameGenerator.java).
- `languageId` [*is* an input into the computation of the cache file name](https://github.com/liferay/liferay-portal/blob/65059440dfaf2b8b365a20f99e83e4cdb15478aa/portal-impl/src/com/liferay/portal/servlet/filters/util/LanguageIdCacheFileNameContributor.java), provided it comes in via a query-string param (as opposed to, say, an `Accept-Language` HTTP header).

As far as I can tell, we always do send `lanuageId` in the query string, generating URLs like: `http://localhost:8080/o/frontend-js-web/liferay/available_languages.jsp?browserId=other&themeId=admin_WAR_admintheme&colorSchemeId=01&minifierType=js&languageId=en_US&b=7200&t=1555941234869`.

If that sounds correct to you, I'll forward this on upstream.

FWIW, the generated files end up looking like `tomcat-9.0.17/work/Catalina/localhost/ROOT/aggregate/http__o_frontend-js-web_liferay_available_languages.jsp0aklrQYqljJWdpOXBpAUbzFhQgL3lUA9RqnFZvmAoR0__E_DATA`.