### PR TITLE
LPS-98874 Getting the node directly from document

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/form.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/form.js
@@ -430,9 +430,7 @@ AUI.add(
 					var fieldName = rule.fieldName;
 					var validatorName = rule.validatorName;
 
-					var field = this.formValidator
-						.getField(fieldName)
-						.getDOMNode();
+					var field = document.getElementById(fieldName);
 
 					A.Do.after(
 						'_setFieldAttribute',


### PR DESCRIPTION
Hi @jbalsas ,

This issue happens because title editor in blogs is a div tag. Because of that when we look for the elements in [aui-form-validator](https://github.com/liferay/alloy-ui/blob/master/src/aui-form-validator/js/aui-form-validator.js#L731) is not found and return null.

Instead of looking the DOM Node using AUI methods we could try to get it directly from document.

Thanks.

Regards.

/cc 