### PR TITLE
LPS-101771 After logging in and the page initializes again, change th…

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
@@ -364,6 +364,29 @@ AUI.add(
 
 					instance.set('timestamp');
 
+					if (
+						instance._cookieKey !=
+						'LFR_SESSION_STATE_' + themeDisplay.getUserId()
+					) {
+						var timestamp = A.Cookie.get(
+							instance._cookieKey,
+							instance._cookieOptions
+						);
+
+						var oldCookieKey = instance._cookieKey;
+
+						instance._cookieKey =
+							'LFR_SESSION_STATE_' + themeDisplay.getUserId();
+
+						A.Cookie.set(
+							instance._cookieKey,
+							timestamp,
+							instance._cookieOptions
+						);
+
+						A.Cookie.remove(oldCookieKey);
+					}
+
 					instance._initEvents();
 
 					instance._startTimer();


### PR DESCRIPTION
Relevant Tickets:
https://issues.liferay.com/browse/LPS-101771

When a user who is not logged in first loads a Liferay page the session is stored under the guest user's userId. After logging in the user should be using their own userId to store the session state. Any new tabs opened while logged in will have the state stored in a session with their own userId. This leads to an issue with the first tab not having the same session Id as all subsequent tabs.