### PR TITLE
LPS-101771 | Sessions not synced between tabs

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
@@ -89,8 +89,6 @@ AUI.add(
 					);
 				},
 
-				_cookieKey: 'LFR_SESSION_STATE_' + themeDisplay.getUserId(),
-
 				_defActivatedFn(event) {
 					var instance = this;
 
@@ -354,6 +352,9 @@ AUI.add(
 
 				initializer() {
 					var instance = this;
+
+					instance._cookieKey =
+						'LFR_SESSION_STATE_' + themeDisplay.getUserId();
 
 					instance._cookieOptions = {
 						path: '/',


### PR DESCRIPTION
Hey @jbalsas ,

This is an alternative solution to https://github.com/jbalsas/liferay-portal/pull/1937. Although that solution works and fixes the bug, it is a patch to the root cause. Root cause was that `instance._cookieKey` did not properly initialize on SPA portal actions, such as login or navigation. It updated only on full page refresh, or opening of the new tab. This caused two tabs to update two different cookies.

Please review the code.

Thank you!

/cc @SamZiemer