### PR TITLE
LPS-104770 Avoid XSS by applying HtmlUtil.escapeJS on getCanonicalURL

### DIFF
--- a/portal-web/docroot/html/common/themes/top_js.jspf
+++ b/portal-web/docroot/html/common/themes/top_js.jspf
@@ -194,7 +194,7 @@
 				String completeURL = PortalUtil.getCurrentCompleteURL(request);
 				%>
 
-				return '<%= PortalUtil.getCanonicalURL(completeURL, themeDisplay, layout, false, false) %>';
+				return '<%= HtmlUtil.escapeJS(PortalUtil.getCanonicalURL(completeURL, themeDisplay, layout, false, false)) %>';
 			},
 			getCDNBaseURL: function() {
 				return '<%= themeDisplay.getCDNBaseURL() %>';


### PR DESCRIPTION
Hey @jbalsas ,

Can you review it, please?

Thanks!

/cc @rolandpakai