### PR TITLE
LPS-103247 layout-admin-web: Make tab switch back to tab with RequiredFieldException error

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/general.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/general.jsp
@@ -252,7 +252,7 @@ renderResponse.setTitle(selLayout.getName(locale));
 	</c:otherwise>
 </c:choose>
 
-<aui:script>
+<aui:script use="liferay-form">
 	var form = document.getElementById('<portlet:namespace />editLayoutFm');
 
 	form.addEventListener('submit', function(event) {
@@ -271,5 +271,16 @@ renderResponse.setTitle(selLayout.getName(locale));
 		) {
 			submitForm(form);
 		}
+	});
+
+	var formValidator = Liferay.Form.get('<portlet:namespace />editLayoutFm')
+		.formValidator;
+
+	formValidator.on('errorField', function(obj) {
+		var ancestor = obj.validator.field.ancestor('div[id$="TabsSection"]');
+		var sectionId = ancestor.attr('id');
+		var tabsId = sectionId.replace('TabsSection', 'TabsId');
+
+		document.querySelector('#' + tabsId + ' a').click();
 	});
 </aui:script>


### PR DESCRIPTION
Ticket Link: https://issues.liferay.com/browse/LPS-103247

Hi @jbalsas,

This PR fixes the issue where a required field error is not properly shown when multiple tabs are involved

Here is the PTR ticket we discussed previously: [PTR-1262](https://issues.liferay.com/browse/PTR-1262)

As discussed on the PTR ticket, one solution was to show the first tab anytime we get a RequiredFieldException in the page edition window

Support feels that this fix would be a safer approach and would be easier to backport to 7.2.x

**Your POC**

On the PTR ticket, you asked us to explore the POC you provided: https://github.com/achaparro/liferay-portal/pull/374 

However, after implementing your POC successfully, we noticed that it introduced new behavior

Here is our working implementation of your POC: https://github.com/ericyanLr/liferay-portal-ee/pull/43

/cc @achaparro @ericyanlr