### PR TITLE
LPS-114062 - Apply the use of content and sheet clay taglibs in user admin

### DIFF
--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/additional_email_addresses.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/additional_email_addresses.jsp
@@ -25,11 +25,17 @@ String emptyResultsMessage = ParamUtil.getString(request, "emptyResultsMessage")
 List<EmailAddress> emailAddresses = EmailAddressServiceUtil.getEmailAddresses(className, classPK);
 %>
 
-<h3 class="autofit-row sheet-subtitle">
-	<span class="autofit-col autofit-col-expand">
+<clay:content-row
+	className="sheet-subtitle"
+	containerElement="h3"
+>
+	<clay:content-col
+		expand="true"
+	>
 		<span class="heading-text"><liferay-ui:message key="additional-email-addresses" /></span>
-	</span>
-	<span class="autofit-col">
+	</clay:content-col>
+
+	<clay:content-col>
 		<span class="heading-end">
 
 			<%
@@ -48,8 +54,8 @@ List<EmailAddress> emailAddresses = EmailAddressServiceUtil.getEmailAddresses(cl
 				url="<%= editURL.toString() %>"
 			/>
 		</span>
-	</span>
-</h3>
+	</clay:content-col>
+</clay:content-row>
 
 <liferay-ui:search-container
 	compactEmptyResultsMessage="<%= true %>"

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/addresses.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/addresses.jsp
@@ -25,12 +25,20 @@ String emptyResultsMessage = ParamUtil.getString(request, "emptyResultsMessage")
 List<Address> addresses = AddressServiceUtil.getAddresses(className, classPK);
 %>
 
-<div class="sheet-header">
-	<h2 class="autofit-row sheet-title">
-		<span class="autofit-col autofit-col-expand">
+<clay:sheet-header>
+	<clay:content-row
+		className="sheet-title"
+		containerElement="h2"
+	>
+		<clay:content-col
+			expand="true"
+		>
 			<span class="heading-text"><liferay-ui:message key="addresses" /></span>
-		</span>
-		<span class="autofit-col">
+		</clay:content-col>
+
+		<clay:content-col
+			expand="true"
+		>
 			<span class="heading-end">
 
 				<%
@@ -49,9 +57,9 @@ List<Address> addresses = AddressServiceUtil.getAddresses(className, classPK);
 					url="<%= editURL.toString() %>"
 				/>
 			</span>
-		</span>
-	</h2>
-</div>
+		</clay:content-col>
+	</clay:content-row>
+</clay:sheet-header>
 
 <c:if test="<%= addresses.isEmpty() %>">
 	<div class="contact-information-empty-results-message-wrapper">
@@ -108,11 +116,13 @@ List<Address> addresses = AddressServiceUtil.getAddresses(className, classPK);
 						</c:if>
 					</td>
 					<td>
-						<span class="autofit-col lfr-search-container-wrapper">
+						<clay:content-col
+							className="lfr-search-container-wrapper"
+						>
 							<liferay-util:include page="/common/address_action.jsp" servletContext="<%= application %>">
 								<liferay-util:param name="addressId" value="<%= String.valueOf(address.getAddressId()) %>" />
 							</liferay-util:include>
-						</span>
+						</clay:content-col>
 					</td>
 				</tr>
 

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/edit_address.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/edit_address.jsp
@@ -59,12 +59,12 @@ PortalUtil.addPortletBreadcrumbEntry(request, editContactInformationDisplayConte
 			/>
 		</div>
 
-		<div class="sheet sheet-lg">
-			<div class="sheet-header">
+		<clay:sheet>
+			<clay:sheet-header>
 				<h2 class="sheet-title"><%= editContactInformationDisplayContext.getSheetTitle() %></h2>
-			</div>
+			</clay:sheet-header>
 
-			<div class="sheet-section">
+			<clay:sheet-section>
 				<aui:model-context bean="<%= address %>" model="<%= Address.class %>" />
 
 				<aui:input checked="<%= (address != null)? address.isPrimary() : false %>" id="addressPrimary" label="make-primary" name="addressPrimary" type="checkbox" />
@@ -110,14 +110,14 @@ PortalUtil.addPortletBreadcrumbEntry(request, editContactInformationDisplayConte
 				</div>
 
 				<aui:input cssClass="mailing-ctrl" fieldParam="addressMailing" id="addressMailing" name="mailing" />
-			</div>
+			</clay:sheet-section>
 
-			<div class="sheet-footer">
+			<clay:sheet-footer>
 				<aui:button primary="<%= true %>" type="submit" />
 
 				<aui:button href="<%= editContactInformationDisplayContext.getRedirect() %>" type="cancel" />
-			</div>
-		</div>
+			</clay:sheet-footer>
+		</clay:sheet>
 	</clay:container-fluid>
 
 	<script>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/edit_email_address.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/edit_email_address.jsp
@@ -53,12 +53,12 @@ PortalUtil.addPortletBreadcrumbEntry(request, editContactInformationDisplayConte
 			/>
 		</div>
 
-		<div class="sheet sheet-lg">
-			<div class="sheet-header">
+		<clay:sheet>
+			<clay:sheet-header>
 				<h2 class="sheet-title"><%= editContactInformationDisplayContext.getSheetTitle() %></h2>
-			</div>
+			</clay:sheet-header>
 
-			<div class="sheet-section">
+			<clay:sheet-section>
 				<aui:model-context bean="<%= emailAddress %>" model="<%= EmailAddress.class %>" />
 
 				<aui:input checked="<%= (emailAddress != null)? emailAddress.isPrimary() : false %>" id="emailAddressPrimary" label="make-primary" name="emailAddressPrimary" type="checkbox" />
@@ -70,13 +70,13 @@ PortalUtil.addPortletBreadcrumbEntry(request, editContactInformationDisplayConte
 				<liferay-ui:error exception="<%= EmailAddressException.class %>" message="please-enter-a-valid-email-address" />
 
 				<aui:input fieldParam="emailAddressAddress" id="emailAddressAddress" name="address" required="<%= true %>" />
-			</div>
+			</clay:sheet-section>
 
-			<div class="sheet-footer">
+			<clay:sheet-footer>
 				<aui:button primary="<%= true %>" type="submit" />
 
 				<aui:button href="<%= editContactInformationDisplayContext.getRedirect() %>" type="cancel" />
-			</div>
-		</div>
+			</clay:sheet-footer>
+		</clay:sheet>
 	</clay:container-fluid>
 </aui:form>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/edit_phone_number.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/edit_phone_number.jsp
@@ -53,12 +53,12 @@ PortalUtil.addPortletBreadcrumbEntry(request, editContactInformationDisplayConte
 			/>
 		</div>
 
-		<div class="sheet sheet-lg">
-			<div class="sheet-header">
+		<clay:sheet>
+			<clay:sheet-header>
 				<h2 class="sheet-title"><%= editContactInformationDisplayContext.getSheetTitle() %></h2>
-			</div>
+			</clay:sheet-header>
 
-			<div class="sheet-section">
+			<clay:sheet-section>
 				<clay:alert
 					message='<%= LanguageUtil.get(request, "extension-must-be-numeric") %>'
 					style="info"
@@ -82,13 +82,13 @@ PortalUtil.addPortletBreadcrumbEntry(request, editContactInformationDisplayConte
 				<aui:input fieldParam="phoneExtension" id="phoneExtension" name="extension">
 					<aui:validator name="digits" />
 				</aui:input>
-			</div>
+			</clay:sheet-section>
 
-			<div class="sheet-footer">
+			<clay:sheet-footer>
 				<aui:button primary="<%= true %>" type="submit" />
 
 				<aui:button href="<%= editContactInformationDisplayContext.getRedirect() %>" type="cancel" />
-			</div>
-		</div>
+			</clay:sheet-footer>
+		</clay:sheet>
 	</clay:container-fluid>
 </aui:form>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/edit_website.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/edit_website.jsp
@@ -53,12 +53,12 @@ PortalUtil.addPortletBreadcrumbEntry(request, editContactInformationDisplayConte
 			/>
 		</div>
 
-		<div class="sheet sheet-lg">
-			<div class="sheet-header">
+		<clay:sheet>
+			<clay:sheet-header>
 				<h2 class="sheet-title"><%= editContactInformationDisplayContext.getSheetTitle() %></h2>
-			</div>
+			</clay:sheet-header>
 
-			<div class="sheet-section">
+			<clay:sheet-section>
 				<clay:alert
 					message='<%= LanguageUtil.format(request, "url-must-start-with-x-or-x", new String[] {"http://", "https://"}, false) %>'
 					style="info"
@@ -76,13 +76,13 @@ PortalUtil.addPortletBreadcrumbEntry(request, editContactInformationDisplayConte
 				<liferay-ui:error exception="<%= WebsiteURLException.class %>" message="please-enter-a-valid-url" />
 
 				<aui:input fieldParam="websiteUrl" id="websiteUrl" name="url" required="<%= true %>" />
-			</div>
+			</clay:sheet-section>
 
-			<div class="sheet-footer">
+			<clay:sheet-footer>
 				<aui:button primary="<%= true %>" type="submit" />
 
 				<aui:button href="<%= editContactInformationDisplayContext.getRedirect() %>" type="cancel" />
-			</div>
-		</div>
+			</clay:sheet-footer>
+		</clay:sheet>
 	</clay:container-fluid>
 </aui:form>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/phone_numbers.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/phone_numbers.jsp
@@ -25,11 +25,17 @@ String emptyResultsMessage = ParamUtil.getString(request, "emptyResultsMessage")
 List<Phone> phones = PhoneServiceUtil.getPhones(className, classPK);
 %>
 
-<h3 class="autofit-row sheet-subtitle">
-	<span class="autofit-col autofit-col-expand">
+<clay:content-row
+	className="sheet-subtitle"
+	containerElement="h3"
+>
+	<clay:content-col
+		expand="true"
+	>
 		<span class="heading-text"><liferay-ui:message key="phone-numbers" /></span>
-	</span>
-	<span class="autofit-col">
+	</clay:content-col>
+
+	<clay:content-col>
 		<span class="heading-end">
 
 			<%
@@ -48,8 +54,8 @@ List<Phone> phones = PhoneServiceUtil.getPhones(className, classPK);
 				url="<%= editURL.toString() %>"
 			/>
 		</span>
-	</span>
-</h3>
+	</clay:content-col>
+</clay:content-row>
 
 <liferay-ui:search-container
 	compactEmptyResultsMessage="<%= true %>"

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/websites.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/websites.jsp
@@ -25,11 +25,17 @@ String emptyResultsMessage = ParamUtil.getString(request, "emptyResultsMessage")
 List<Website> websites = WebsiteServiceUtil.getWebsites(className, classPK);
 %>
 
-<h3 class="autofit-row sheet-subtitle">
-	<span class="autofit-col autofit-col-expand">
+<clay:content-row
+	className="sheet-subtitle"
+	containerElement="h3"
+>
+	<clay:content-col
+		expand="true"
+	>
 		<span class="heading-text"><liferay-ui:message key="websites" /></span>
-	</span>
-	<span class="autofit-col">
+	</clay:content-col>
+
+	<clay:content-col>
 		<span class="heading-end">
 
 			<%
@@ -48,8 +54,8 @@ List<Website> websites = WebsiteServiceUtil.getWebsites(className, classPK);
 				url="<%= editURL.toString() %>"
 			/>
 		</span>
-	</span>
-</h3>
+	</clay:content-col>
+</clay:content-row>
 
 <liferay-ui:search-container
 	compactEmptyResultsMessage="<%= true %>"

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/edit_organization_navigation.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/edit_organization_navigation.jsp
@@ -21,23 +21,23 @@ OrganizationScreenNavigationDisplayContext organizationScreenNavigationDisplayCo
 %>
 
 <aui:form action="<%= organizationScreenNavigationDisplayContext.getEditOrganizationActionURL() %>" cssClass="portlet-users-admin-edit-organization" method="post" name="fm">
-	<div class="sheet sheet-lg">
+	<clay:sheet>
 		<c:if test="<%= organizationScreenNavigationDisplayContext.isShowTitle() %>">
-			<div class="sheet-header">
+			<clay:sheet-header>
 				<h2 class="sheet-title"><%= organizationScreenNavigationDisplayContext.getFormLabel() %></h2>
-			</div>
+			</clay:sheet-header>
 		</c:if>
 
-		<div class="sheet-section">
+		<clay:sheet-section>
 			<liferay-util:include page="<%= organizationScreenNavigationDisplayContext.getJspPath() %>" servletContext="<%= application %>" />
-		</div>
+		</clay:sheet-section>
 
 		<c:if test="<%= organizationScreenNavigationDisplayContext.isShowControls() %>">
-			<div class="sheet-footer">
+			<clay:sheet-footer>
 				<aui:button primary="<%= true %>" type="submit" />
 
 				<aui:button href="<%= organizationScreenNavigationDisplayContext.getBackURL() %>" type="cancel" />
-			</div>
+			</clay:sheet-footer>
 		</c:if>
-	</div>
+	</clay:sheet>
 </aui:form>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/edit_user_navigation.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/edit_user_navigation.jsp
@@ -74,25 +74,25 @@ redirect = HttpUtil.addParameter(redirect, renderResponse.getNamespace() + "scre
 	<aui:input name="screenNavigationCategoryKey" type="hidden" value="<%= screenNavigationCategoryKey %>" />
 	<aui:input name="screenNavigationEntryKey" type="hidden" value="<%= screenNavigationEntryKey %>" />
 
-	<div class="sheet sheet-lg">
+	<clay:sheet>
 		<c:if test="<%= (boolean)request.getAttribute(UsersAdminWebKeys.SHOW_TITLE) %>">
-			<div class="sheet-header">
+			<clay:sheet-header>
 				<h2 class="sheet-title"><%= formLabel %></h2>
-			</div>
+			</clay:sheet-header>
 		</c:if>
 
-		<div class="sheet-section">
+		<clay:sheet-section>
 			<liferay-util:include page="<%= jspPath %>" servletContext="<%= application %>" />
-		</div>
+		</clay:sheet-section>
 
 		<c:if test="<%= editable && (boolean)request.getAttribute(UsersAdminWebKeys.SHOW_CONTROLS) %>">
-			<div class="sheet-footer">
+			<clay:sheet-footer>
 				<aui:button primary="<%= true %>" type="submit" />
 
 				<c:if test="<%= !portletName.equals(UsersAdminPortletKeys.MY_ACCOUNT) %>">
 					<aui:button href="<%= backURL %>" type="cancel" />
 				</c:if>
-			</div>
+			</clay:sheet-footer>
 		</c:if>
-	</div>
+	</clay:sheet>
 </aui:form>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/addresses.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/addresses.jsp
@@ -28,8 +28,8 @@ request.setAttribute("contact_information.jsp-mvcActionPath", "/users_admin/upda
 
 <aui:input name="classPK" type="hidden" value="<%= String.valueOf(organizationId) %>" />
 
-<div class="sheet-section">
+<clay:sheet-section>
 	<liferay-util:include page="/common/addresses.jsp" servletContext="<%= application %>">
 		<liferay-util:param name="emptyResultsMessage" value="this-organization-does-not-have-any-addresses" />
 	</liferay-util:include>
-</div>
+</clay:sheet-section>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/contact_information.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/contact_information.jsp
@@ -25,20 +25,20 @@ request.setAttribute("contact_information.jsp-className", Organization.class.get
 request.setAttribute("contact_information.jsp-classPK", organizationId);
 %>
 
-<div class="sheet-section">
+<clay:sheet-section>
 	<liferay-util:include page="/common/phone_numbers.jsp" servletContext="<%= application %>">
 		<liferay-util:param name="emptyResultsMessage" value="this-organization-does-not-have-any-phone-numbers" />
 	</liferay-util:include>
-</div>
+</clay:sheet-section>
 
-<div class="sheet-section">
+<clay:sheet-section>
 	<liferay-util:include page="/common/additional_email_addresses.jsp" servletContext="<%= application %>">
 		<liferay-util:param name="emptyResultsMessage" value="this-organization-does-not-have-any-additional-email-addresses" />
 	</liferay-util:include>
-</div>
+</clay:sheet-section>
 
-<div class="sheet-section">
+<clay:sheet-section>
 	<liferay-util:include page="/common/websites.jsp" servletContext="<%= application %>">
 		<liferay-util:param name="emptyResultsMessage" value="this-organization-does-not-have-any-websites" />
 	</liferay-util:include>
-</div>
+</clay:sheet-section>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/edit_opening_hours.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/edit_opening_hours.jsp
@@ -53,12 +53,12 @@ PortalUtil.addPortletBreadcrumbEntry(request, editContactInformationDisplayConte
 			/>
 		</div>
 
-		<div class="sheet sheet-lg">
-			<div class="sheet-header">
+		<clay:sheet>
+			<clay:sheet-header>
 				<h2 class="sheet-title"><%= editContactInformationDisplayContext.getSheetTitle() %></h2>
-			</div>
+			</clay:sheet-header>
 
-			<div class="sheet-section">
+			<clay:sheet-section>
 				<aui:model-context bean="<%= orgLabor %>" model="<%= OrgLabor.class %>" />
 
 				<liferay-ui:error key="<%= NoSuchListTypeException.class.getName() + editContactInformationDisplayContext.getClassName() + ListTypeConstants.ORGANIZATION_SERVICE %>" message="please-select-a-type" />
@@ -119,13 +119,13 @@ PortalUtil.addPortletBreadcrumbEntry(request, editContactInformationDisplayConte
 					%>
 
 				</table>
-			</div>
+			</clay:sheet-section>
 
-			<div class="sheet-footer">
+			<clay:sheet-footer>
 				<aui:button primary="<%= true %>" type="submit" />
 
 				<aui:button href="<%= editContactInformationDisplayContext.getRedirect() %>" type="cancel" />
-			</div>
-		</div>
+			</clay:sheet-footer>
+		</clay:sheet>
 	</clay:container-fluid>
 </aui:form>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/information.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/information.jsp
@@ -30,11 +30,11 @@ Organization organization = organizationScreenNavigationDisplayContext.getOrgani
 	<liferay-util:include page="/organization/details.jsp" servletContext="<%= application %>" />
 </div>
 
-<div class="sheet-section">
+<clay:sheet-section>
 	<liferay-util:include page="/organization/parent_organization.jsp" servletContext="<%= application %>" />
-</div>
+</clay:sheet-section>
 
-<div class="sheet-section">
+<clay:sheet-section>
 	<h3 class="sheet-subtitle"><liferay-ui:message key="more-information" /></h3>
 
 	<div class="form-group">
@@ -44,12 +44,12 @@ Organization organization = organizationScreenNavigationDisplayContext.getOrgani
 	<div class="form-group">
 		<liferay-util:include page="/organization/comments.jsp" servletContext="<%= application %>" />
 	</div>
-</div>
+</clay:sheet-section>
 
 <c:if test="<%= CustomFieldsUtil.hasVisibleCustomFields(company.getCompanyId(), Organization.class) %>">
-	<div class="sheet-section">
+	<clay:sheet-section>
 		<h4 class="sheet-tertiary-title"><liferay-ui:message key="custom-fields" /></h4>
 
 		<liferay-util:include page="/organization/custom_fields.jsp" servletContext="<%= application %>" />
-	</div>
+	</clay:sheet-section>
 </c:if>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/opening_hours.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/opening_hours.jsp
@@ -24,12 +24,18 @@ long organizationId = organizationScreenNavigationDisplayContext.getOrganization
 List<OrgLabor> orgLabors = OrgLaborServiceUtil.getOrgLabors(organizationId);
 %>
 
-<div class="sheet-header">
-	<h2 class="autofit-row sheet-title">
-		<span class="autofit-col autofit-col-expand">
+<clay:sheet-header>
+	<clay:content-row
+		className="sheet-title"
+		containerElement="h3"
+	>
+		<clay:content-col
+			expand="true"
+		>
 			<span class="heading-text"><%= organizationScreenNavigationDisplayContext.getFormLabel() %></span>
-		</span>
-		<span class="autofit-col">
+		</clay:content-col>
+
+		<clay:content-col>
 			<span class="heading-end">
 
 				<%
@@ -48,9 +54,9 @@ List<OrgLabor> orgLabors = OrgLaborServiceUtil.getOrgLabors(organizationId);
 					url="<%= editURL.toString() %>"
 				/>
 			</span>
-		</span>
-	</h2>
-</div>
+		</clay:content-col>
+	</clay:content-row>
+</clay:sheet-header>
 
 <c:if test="<%= orgLabors.isEmpty() %>">
 	<div class="contact-information-empty-results-message-wrapper">
@@ -76,16 +82,21 @@ List<OrgLabor> orgLabors = OrgLaborServiceUtil.getOrgLabors(organizationId);
 	%>
 
 		<div class="opening-hours-entry">
-			<div class="autofit-row opening-hours-header">
-				<span class="autofit-col">
+			<clay:content-row
+				className="opening-hours-header"
+			>
+				<clay:content-col>
 					<h5><%= orgLaborDisplay.getTitle() %></h5>
-				</span>
-				<span class="autofit-col lfr-search-container-wrapper">
+				</clay:content-col>
+
+				<clay:content-col
+					className="lfr-search-container-wrapper"
+				>
 					<liferay-util:include page="/organization/opening_hours_action.jsp" servletContext="<%= application %>">
 						<liferay-util:param name="orgLaborId" value="<%= String.valueOf(orgLabor.getOrgLaborId()) %>" />
 					</liferay-util:include>
-				</span>
-			</div>
+				</clay:content-col>
+			</clay:content-row>
 
 			<div class="table-responsive">
 				<table class="table table-autofit">

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/organization_site.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/organization_site.jsp
@@ -78,7 +78,7 @@ if (organization != null) {
 
 <c:choose>
 	<c:when test="<%= (organizationGroup == null) || GroupPermissionUtil.contains(permissionChecker, organizationGroup, ActionKeys.UPDATE) %>">
-		<div class="sheet-section">
+		<clay:sheet-section>
 			<c:choose>
 				<c:when test="<%= (organization == null) || ((publicLayoutSetPrototype == null) && (privateLayoutSetPrototype == null)) %>">
 					<p class="sheet-text"><liferay-ui:message key="by-clicking-this-toggle-you-could-create-a-public-and-or-private-site-for-your-organization" /></p>
@@ -109,14 +109,14 @@ if (organization != null) {
 					/>
 				</div>
 			</c:if>
-		</div>
+		</clay:sheet-section>
 
 		<%
 		boolean hasUnlinkLayoutSetPrototypePermission = PortalPermissionUtil.contains(permissionChecker, ActionKeys.UNLINK_LAYOUT_SET_PROTOTYPE);
 		%>
 
 		<div id="<portlet:namespace />siteTemplates">
-			<div class="sheet-section">
+			<clay:sheet-section>
 				<h3 class="sheet-subtitle"><liferay-ui:message key="public-pages" /></h3>
 
 				<c:choose>
@@ -190,9 +190,9 @@ if (organization != null) {
 						</c:choose>
 					</c:otherwise>
 				</c:choose>
-			</div>
+			</clay:sheet-section>
 
-			<div class="sheet-section">
+			<clay:sheet-section>
 				<h3 class="sheet-subtitle"><liferay-ui:message key="private-pages" /></h3>
 
 				<c:choose>
@@ -266,9 +266,9 @@ if (organization != null) {
 						</c:choose>
 					</c:otherwise>
 				</c:choose>
-			</div>
+			</clay:sheet-section>
 
-			<div class="sheet-footer">
+			<clay:sheet-footer>
 				<aui:button primary="<%= true %>" type="submit" />
 
 				<%
@@ -276,7 +276,7 @@ if (organization != null) {
 				%>
 
 				<aui:button href="<%= organizationScreenNavigationDisplayContext.getBackURL() %>" type="cancel" />
-			</div>
+			</clay:sheet-footer>
 		</div>
 
 		<%

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/parent_organization.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/parent_organization.jsp
@@ -66,11 +66,17 @@ if (parentOrganization != null) {
 }
 %>
 
-<h3 class="autofit-row sheet-subtitle">
-	<span class="autofit-col autofit-col-expand">
+<clay:content-row
+	className="sheet-subtitle"
+	containerElement="h3"
+>
+	<clay:content-col
+		expand="true"
+	>
 		<span class="heading-text"><liferay-ui:message key="parent-organization" /></span>
-	</span>
-	<span class="autofit-col">
+	</clay:content-col>
+
+	<clay:content-col>
 		<span class="heading-end">
 			<liferay-ui:icon
 				cssClass="modify-link"
@@ -81,8 +87,8 @@ if (parentOrganization != null) {
 				url="javascript:;"
 			/>
 		</span>
-	</span>
-</h3>
+	</clay:content-col>
+</clay:content-row>
 
 <liferay-util:buffer
 	var="removeOrganizationIcon"

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/addresses.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/addresses.jsp
@@ -28,8 +28,8 @@ request.setAttribute("contact_information.jsp-mvcActionPath", "/users_admin/upda
 
 <aui:input name="classPK" type="hidden" value="<%= String.valueOf(selContactId) %>" />
 
-<div class="sheet-section">
+<clay:sheet-section>
 	<liferay-util:include page="/common/addresses.jsp" servletContext="<%= application %>">
 		<liferay-util:param name="emptyResultsMessage" value="this-user-does-not-have-any-addresses" />
 	</liferay-util:include>
-</div>
+</clay:sheet-section>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/announcements.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/announcements.jsp
@@ -38,9 +38,9 @@ else {
 }
 %>
 
-<div class="sheet-section">
+<clay:sheet-section>
 	<div class="text-muted"><liferay-ui:message key="select-the-delivery-options-for-alerts-and-announcements" /></div>
-</div>
+</clay:sheet-section>
 
 <liferay-ui:search-container>
 	<liferay-ui:search-container-results

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/contact_information.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/contact_information.jsp
@@ -34,44 +34,44 @@ request.setAttribute("contact_information.jsp-className", Contact.class.getName(
 request.setAttribute("contact_information.jsp-classPK", selContactId);
 %>
 
-<div class="sheet-section">
+<clay:sheet-section>
 	<liferay-util:include page="/common/phone_numbers.jsp" servletContext="<%= application %>">
 		<liferay-util:param name="emptyResultsMessage" value="this-user-does-not-have-any-phone-numbers" />
 	</liferay-util:include>
-</div>
+</clay:sheet-section>
 
-<div class="sheet-section">
+<clay:sheet-section>
 	<liferay-util:include page="/common/additional_email_addresses.jsp" servletContext="<%= application %>">
 		<liferay-util:param name="emptyResultsMessage" value="this-user-does-not-have-any-additional-email-addresses" />
 	</liferay-util:include>
-</div>
+</clay:sheet-section>
 
-<div class="sheet-section">
+<clay:sheet-section>
 	<liferay-util:include page="/common/websites.jsp" servletContext="<%= application %>">
 		<liferay-util:param name="emptyResultsMessage" value="this-user-does-not-have-any-websites" />
 	</liferay-util:include>
-</div>
+</clay:sheet-section>
 
-<div class="sheet-section">
+<clay:sheet-section>
 	<h3 class="sheet-subtitle"><liferay-ui:message key="instant-messenger" /></h3>
 
 	<liferay-util:include page="/user/instant_messenger.jsp" servletContext="<%= application %>" />
-</div>
+</clay:sheet-section>
 
-<div class="sheet-section">
+<clay:sheet-section>
 	<h3 class="sheet-subtitle"><liferay-ui:message key="sms" /></h3>
 
 	<liferay-util:include page="/user/sms.jsp" servletContext="<%= application %>" />
-</div>
+</clay:sheet-section>
 
-<div class="sheet-section">
+<clay:sheet-section>
 	<h3 class="sheet-subtitle"><liferay-ui:message key="social-network" /></h3>
 
 	<liferay-util:include page="/user/social_network.jsp" servletContext="<%= application %>" />
-</div>
+</clay:sheet-section>
 
-<div class="sheet-section">
+<clay:sheet-section>
 	<h3 class="sheet-subtitle"><liferay-ui:message key="openid" /></h3>
 
 	<liferay-util:include page="/user/openid.jsp" servletContext="<%= application %>" />
-</div>
+</clay:sheet-section>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/custom_fields.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/custom_fields.jsp
@@ -20,15 +20,17 @@
 User selUser = (User)request.getAttribute(UsersAdminWebKeys.SELECTED_USER);
 %>
 
-<div class="autofit-padded-no-gutters autofit-row">
-	<span class="autofit-col autofit-col-expand">
+<clay:content-row>
+	<clay:content-col
+		expand="true"
+	>
 		<h4 class="sheet-tertiary-title">
 			<liferay-ui:message key="custom-fields" />
 		</h4>
-	</span>
+	</clay:content-col>
 
 	<c:if test="<%= PortletPermissionUtil.contains(permissionChecker, PortletKeys.EXPANDO, ActionKeys.ACCESS_IN_CONTROL_PANEL) %>">
-		<span class="autofit-col">
+		<clay:content-col>
 
 			<%
 			boolean hasVisibleCustomFields = CustomFieldsUtil.hasVisibleCustomFields(company.getCompanyId(), User.class);
@@ -53,9 +55,9 @@ User selUser = (User)request.getAttribute(UsersAdminWebKeys.SELECTED_USER);
 				method="get"
 				url="<%= customFieldsURL.toString() %>"
 			/>
-		</span>
+		</clay:content-col>
 	</c:if>
-</div>
+</clay:content-row>
 
 <liferay-expando:custom-attribute-list
 	className="com.liferay.portal.kernel.model.User"

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/information.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/information.jsp
@@ -34,7 +34,7 @@ User selUser = (User)request.getAttribute(UsersAdminWebKeys.SELECTED_USER);
 	<liferay-util:include page="/user/personal_information.jsp" servletContext="<%= application %>" />
 </div>
 
-<div class="sheet-section">
+<clay:sheet-section>
 	<h3 class="sheet-subtitle"><liferay-ui:message key="more-information" /></h3>
 
 	<div class="form-group">
@@ -44,8 +44,8 @@ User selUser = (User)request.getAttribute(UsersAdminWebKeys.SELECTED_USER);
 	<div class="form-group">
 		<liferay-util:include page="/user/comments.jsp" servletContext="<%= application %>" />
 	</div>
-</div>
+</clay:sheet-section>
 
-<div class="sheet-section">
+<clay:sheet-section>
 	<liferay-util:include page="/user/custom_fields.jsp" servletContext="<%= application %>" />
-</div>
+</clay:sheet-section>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/memberships.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/memberships.jsp
@@ -18,12 +18,12 @@
 
 <liferay-util:dynamic-include key="com.liferay.users.admin.web#/user/memberships.jsp#pre" />
 
-<div class="sheet-section">
+<clay:sheet-section>
 	<liferay-util:include page="/user/sites.jsp" servletContext="<%= application %>" />
-</div>
+</clay:sheet-section>
 
-<div class="sheet-section">
+<clay:sheet-section>
 	<liferay-util:include page="/user/user_groups.jsp" servletContext="<%= application %>" />
-</div>
+</clay:sheet-section>
 
 <liferay-util:dynamic-include key="com.liferay.users.admin.web#/user/memberships.jsp#post" />

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/organizations.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/organizations.jsp
@@ -33,13 +33,18 @@ currentURLObj.setParameter("historyKey", renderResponse.getNamespace() + "organi
 
 <liferay-ui:membership-policy-error />
 
-<h3 class="autofit-row sheet-subtitle">
-	<span class="autofit-col autofit-col-expand">
+<clay:content-row
+	className="sheet-subtitle"
+	containerElement="h3"
+>
+	<clay:content-col
+		expand="true"
+	>
 		<span class="heading-text"><liferay-ui:message key="organizations" /></span>
-	</span>
+	</clay:content-col>
 
 	<c:if test="<%= !portletName.equals(myAccountPortletId) %>">
-		<span class="autofit-col">
+		<clay:content-col>
 			<span class="heading-end">
 				<liferay-ui:icon
 					cssClass="modify-link"
@@ -51,9 +56,9 @@ currentURLObj.setParameter("historyKey", renderResponse.getNamespace() + "organi
 					url="javascript:;"
 				/>
 			</span>
-		</span>
+		</clay:content-col>
 	</c:if>
-</h3>
+</clay:content-row>
 
 <liferay-util:buffer
 	var="removeOrganizationIcon"

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/password.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/password.jsp
@@ -128,7 +128,7 @@ else {
 <liferay-ui:error exception="<%= UserPasswordException.MustNotBeTrivial.class %>" message="that-password-uses-common-words-please-enter-a-password-that-is-harder-to-guess-i-e-contains-a-mix-of-numbers-and-letters" />
 <liferay-ui:error exception="<%= UserPasswordException.MustNotContainDictionaryWords.class %>" message="that-password-uses-common-dictionary-words" />
 
-<div class="sheet-section">
+<clay:sheet-section>
 	<h3 class="sheet-subtitle"><liferay-ui:message key="password" /></h3>
 
 	<!-- Begin LPS-38289 and LPS-55993 and LPS-61876 -->
@@ -153,10 +153,10 @@ else {
 	<c:if test="<%= (selUser == null) || (user.getUserId() != selUser.getUserId()) %>">
 		<aui:input disabled="<%= passwordResetDisabled %>" label="require-password-reset" name="passwordReset" type="checkbox" value="<%= passwordReset %>" />
 	</c:if>
-</div>
+</clay:sheet-section>
 
 <c:if test="<%= PropsValues.USERS_REMINDER_QUERIES_ENABLED && portletName.equals(myAccountPortletId) %>">
-	<div class="sheet-section">
+	<clay:sheet-section>
 		<h3 class="sheet-subtitle"><liferay-ui:message key="reminder" /></h3>
 
 		<%
@@ -172,7 +172,7 @@ else {
 		</c:if>
 
 		<aui:input autocomplete='<%= PropsValues.COMPANY_SECURITY_PASSWORD_REMINDER_QUERY_FORM_AUTOCOMPLETE ? "on" : "off" %>' label="answer" maxlength="<%= ModelHintsConstants.TEXT_MAX_LENGTH %>" name="reminderQueryAnswer" size="50" value="<%= selUser.getReminderQueryAnswer() %>" />
-	</div>
+	</clay:sheet-section>
 
 	<aui:script sandbox="<%= true %>">
 		var reminderQueryQuestionSelect = document.getElementById(

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/personal_site.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/personal_site.jsp
@@ -74,7 +74,7 @@ if (selUser != null) {
 boolean hasUnlinkLayoutSetPrototypePermission = PortalPermissionUtil.contains(permissionChecker, ActionKeys.UNLINK_LAYOUT_SET_PROTOTYPE);
 %>
 
-<div class="sheet-section">
+<clay:sheet-section>
 	<h3 class="sheet-subtitle"><liferay-ui:message key="profile" /></h3>
 
 	<c:choose>
@@ -151,9 +151,9 @@ boolean hasUnlinkLayoutSetPrototypePermission = PortalPermissionUtil.contains(pe
 			</aui:field-wrapper>
 		</c:otherwise>
 	</c:choose>
-</div>
+</clay:sheet-section>
 
-<div class="sheet-section">
+<clay:sheet-section>
 	<h3 class="sheet-subtitle"><liferay-ui:message key="dashboard" /></h3>
 
 	<c:choose>
@@ -230,7 +230,7 @@ boolean hasUnlinkLayoutSetPrototypePermission = PortalPermissionUtil.contains(pe
 			</aui:field-wrapper>
 		</c:otherwise>
 	</c:choose>
-</div>
+</clay:sheet-section>
 
 <%
 if ((selUser == null) && layoutSetPrototypes.isEmpty()) {

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/roles.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/roles.jsp
@@ -66,14 +66,19 @@ String organizationRoleSyncEntitiesEventName = liferayPortletResponse.getNamespa
 <aui:input name="deleteGroupRolesRoleIds" type="hidden" />
 <aui:input name="deleteRoleIds" type="hidden" />
 
-<div class="sheet-section">
-	<h3 class="autofit-row sheet-subtitle">
-		<span class="autofit-col autofit-col-expand">
+<clay:sheet-section>
+	<clay:content-row
+		className="sheet-subtitle"
+		containerElement="h3"
+	>
+		<clay:content-col
+			expand="true"
+		>
 			<span class="heading-text"><liferay-ui:message key="regular-roles" /></span>
-		</span>
+		</clay:content-col>
 
 		<c:if test="<%= !portletName.equals(myAccountPortletId) %>">
-			<span class="autofit-col">
+			<clay:content-col>
 				<span class="heading-end">
 					<liferay-ui:icon
 						cssClass="modify-link"
@@ -85,9 +90,9 @@ String organizationRoleSyncEntitiesEventName = liferayPortletResponse.getNamespa
 						url="javascript:;"
 					/>
 				</span>
-			</span>
+			</clay:content-col>
 		</c:if>
-	</h3>
+	</clay:content-row>
 
 	<liferay-ui:search-container
 		compactEmptyResultsMessage="<%= true %>"
@@ -243,16 +248,21 @@ String organizationRoleSyncEntitiesEventName = liferayPortletResponse.getNamespa
 			/>
 		</liferay-ui:search-container>
 	</c:if>
-</div>
+</clay:sheet-section>
 
-<div class="sheet-section">
-	<h3 class="autofit-row sheet-subtitle">
-		<span class="autofit-col autofit-col-expand">
+<clay:sheet-section>
+	<clay:content-row
+		className="sheet-subtitle"
+		containerElement="h3"
+	>
+		<clay:content-col
+			expand="true"
+		>
 			<span class="heading-text"><liferay-ui:message key="organization-roles" /></span>
-		</span>
+		</clay:content-col>
 
 		<c:if test="<%= !portletName.equals(myAccountPortletId) && (!organizations.isEmpty() || !organizationRoles.isEmpty()) %>">
-			<span class="autofit-col">
+			<clay:content-col>
 				<span class="heading-end">
 					<liferay-ui:icon
 						cssClass="modify-link"
@@ -264,9 +274,9 @@ String organizationRoleSyncEntitiesEventName = liferayPortletResponse.getNamespa
 						url="javascript:;"
 					/>
 				</span>
-			</span>
+			</clay:content-col>
 		</c:if>
-	</h3>
+	</clay:content-row>
 
 	<c:if test="<%= organizations.isEmpty() && organizationRoles.isEmpty() %>">
 		<div class="text-muted"><liferay-ui:message key="this-user-does-not-belong-to-an-organization-to-which-an-organization-role-can-be-assigned" /></div>
@@ -473,16 +483,21 @@ String organizationRoleSyncEntitiesEventName = liferayPortletResponse.getNamespa
 			}
 		</aui:script>
 	</c:if>
-</div>
+</clay:sheet-section>
 
-<div class="sheet-section">
-	<h3 class="autofit-row sheet-subtitle">
-		<span class="autofit-col autofit-col-expand">
+<clay:sheet-section>
+	<clay:content-row
+		className="sheet-subtitle"
+		containerElement="h3"
+	>
+		<clay:content-col
+			expand="true"
+		>
 			<span class="heading-text"><liferay-ui:message key="site-roles" /></span>
-		</span>
+		</clay:content-col>
 
 		<c:if test="<%= !portletName.equals(myAccountPortletId) && (!groups.isEmpty() || !siteRoles.isEmpty()) %>">
-			<span class="autofit-col">
+			<clay:content-col>
 				<span class="heading-end">
 					<liferay-ui:icon
 						cssClass="modify-link"
@@ -494,9 +509,9 @@ String organizationRoleSyncEntitiesEventName = liferayPortletResponse.getNamespa
 						url="javascript:;"
 					/>
 				</span>
-			</span>
+			</clay:content-col>
 		</c:if>
-	</h3>
+	</clay:content-row>
 
 	<c:if test="<%= groups.isEmpty() && siteRoles.isEmpty() %>">
 		<div class="text-muted"><liferay-ui:message key="this-user-does-not-belong-to-a-site-to-which-a-site-role-can-be-assigned" /></div>
@@ -943,6 +958,6 @@ String organizationRoleSyncEntitiesEventName = liferayPortletResponse.getNamespa
 			});
 		</aui:script>
 	</c:if>
-</div>
+</clay:sheet-section>
 
 <liferay-util:dynamic-include key="com.liferay.users.admin.web#/user/roles.jsp#post" />

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/sites.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/sites.jsp
@@ -31,13 +31,18 @@ currentURLObj.setParameter("historyKey", renderResponse.getNamespace() + "sites"
 
 <liferay-ui:membership-policy-error />
 
-<h3 class="autofit-row sheet-subtitle">
-	<span class="autofit-col autofit-col-expand">
+<clay:content-row
+	className="sheet-subtitle"
+	containerElement="h3"
+>
+	<clay:content-col
+		expand="true"
+	>
 		<span class="heading-text"><liferay-ui:message key="sites" /></span>
-	</span>
+	</clay:content-col>
 
 	<c:if test="<%= !portletName.equals(myAccountPortletId) %>">
-		<span class="autofit-col">
+		<clay:content-col>
 			<span class="heading-end">
 				<liferay-ui:icon
 					cssClass="modify-link"
@@ -48,9 +53,9 @@ currentURLObj.setParameter("historyKey", renderResponse.getNamespace() + "sites"
 					url="javascript:;"
 				/>
 			</span>
-		</span>
+		</clay:content-col>
 	</c:if>
-</h3>
+</clay:content-row>
 
 <liferay-util:buffer
 	var="removeGroupIcon"

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/user_groups.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/user_groups.jsp
@@ -30,13 +30,18 @@ currentURLObj.setParameter("historyKey", renderResponse.getNamespace() + "userGr
 
 <liferay-ui:membership-policy-error />
 
-<h3 class="autofit-row sheet-subtitle">
-	<span class="autofit-col autofit-col-expand">
+<clay:content-row
+	className="sheet-subtitle"
+	containerElement="h3"
+>
+	<clay:content-col
+		expand="true"
+	>
 		<span class="heading-text"><liferay-ui:message key="user-groups" /></span>
-	</span>
+	</clay:content-col>
 
 	<c:if test="<%= !portletName.equals(myAccountPortletId) %>">
-		<span class="autofit-col">
+		<clay:content-col>
 			<span class="heading-end">
 				<liferay-ui:icon
 					cssClass="modify-link"
@@ -47,9 +52,9 @@ currentURLObj.setParameter("historyKey", renderResponse.getNamespace() + "userGr
 					url="javascript:;"
 				/>
 			</span>
-		</span>
+		</clay:content-col>
 	</c:if>
-</h3>
+</clay:content-row>
 
 <liferay-util:buffer
 	var="removeUserGroupIcon"


### PR DESCRIPTION
Hey @jbalsas 

As part of our effort to Improve HTML Layout Generation Strategies in DXP, here a PR about changing `autofit-*` and `sheet-*` for `clay:sheet*` and `clay:content*` in JSPs in account-admin-web.

We have funded out a case currently don't have tag to use to template them:

`<div class="sheet-lg" id="breadcrumb">`

/cc @eduardoallegrini