### PR TITLE
LPS-114061 - Apply the use of sheet clay taglib in user-associated-data-web

### DIFF
--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/content/page.jsp
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/content/page.jsp
@@ -18,7 +18,7 @@
 
 <c:if test="<%= !dataSiteLevelPortlets.isEmpty() %>">
 	<aui:fieldset cssClass="options-group" markupView="lexicon">
-		<div class="sheet-section">
+		<clay:sheet-section>
 			<h3 class="sheet-subtitle"><liferay-ui:message key="content" /></h3>
 
 			<ul class="list-unstyled">
@@ -215,6 +215,6 @@
 					</ul>
 				</li>
 			</ul>
-		</div>
+		</clay:sheet-section>
 	</aui:fieldset>
 </c:if>

--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/deletions/page.jsp
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/deletions/page.jsp
@@ -18,7 +18,7 @@
 
 <c:if test="<%= cmd.equals(Constants.EXPORT) || cmd.equals(Constants.IMPORT) || cmd.equals(Constants.PUBLISH) %>">
 	<aui:fieldset cssClass="options-group" markupView="lexicon">
-		<div class="sheet-section">
+		<clay:sheet-section>
 			<h3 class="sheet-subtitle"><liferay-ui:message key="deletions" /></h3>
 
 			<c:if test="<%= !cmd.equals(Constants.EXPORT) %>">
@@ -43,6 +43,6 @@
 				label="<%= individualDeletionsTitle %>"
 				name="<%= PortletDataHandlerKeys.DELETIONS %>"
 			/>
-		</div>
+		</clay:sheet-section>
 	</aui:fieldset>
 </c:if>

--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/permissions/page.jsp
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/permissions/page.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/permissions/init.jsp" %>
 
 <aui:fieldset cssClass="options-group" markupView="lexicon">
-	<div class="sheet-section">
+	<clay:sheet-section>
 		<h3 class="sheet-subtitle"><liferay-ui:message key="permissions" /></h3>
 
 		<%
@@ -31,5 +31,5 @@
 			label="<%= inputTitle %>"
 			name="<%= PortletDataHandlerKeys.PERMISSIONS %>"
 		/>
-	</div>
+	</clay:sheet-section>
 </aui:fieldset>

--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/select_pages/page.jsp
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/select_pages/page.jsp
@@ -19,7 +19,7 @@
 <aui:input name="layoutIds" type="hidden" value="<%= ExportImportHelperUtil.getSelectedLayoutsJSON(selectPagesGroupId, selectPagesPrivateLayout, selectedLayoutIds) %>" />
 
 <aui:fieldset cssClass="options-group" id="pages-fieldset" markupView="lexicon">
-	<div class="sheet-section">
+	<clay:sheet-section>
 		<h3 class="sheet-subtitle"><liferay-ui:message key="pages" /></h3>
 
 		<ul class="flex-container layout-selector" id="<portlet:namespace />pages">
@@ -216,5 +216,5 @@
 				</li>
 			</ul>
 		</c:if>
-	</div>
+	</clay:sheet-section>
 </aui:fieldset>

--- a/modules/apps/sync/sync-web/src/main/resources/META-INF/resources/settings.jsp
+++ b/modules/apps/sync/sync-web/src/main/resources/META-INF/resources/settings.jsp
@@ -62,11 +62,11 @@ if (deployed && oAuthEnabled) {
 <aui:form action="<%= configurationActionURL %>" cssClass="container-fluid container-fluid-max-xl container-form-lg" method="post" name="fm" onSubmit='<%= "event.preventDefault(); " + renderResponse.getNamespace() + "updatePreferences();" %>'>
 	<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
 
-	<div class="sheet sheet-lg">
+	<clay:sheet>
 		<liferay-ui:error exception="<%= OAuthPortletUndeployedException.class %>" message="oauth-publisher-is-not-deployed" />
 
 		<aui:fieldset>
-			<div class="sheet-section">
+			<clay:sheet-section>
 				<h3 class="sheet-subtitle"><liferay-ui:message key="general" /></h3>
 
 				<aui:input label="allow-the-use-of-sync" name="enabled" type="toggle-switch" value="<%= enabled %>" />
@@ -75,10 +75,10 @@ if (deployed && oAuthEnabled) {
 				<c:if test="<%= deployed %>">
 					<aui:input helpMessage="oauth-enabled-help" label="oauth-enabled" name="oAuthEnabled" type="toggle-switch" value="<%= oAuthEnabled %>" />
 				</c:if>
-			</div>
+			</clay:sheet-section>
 		</aui:fieldset>
 
-		<div class="sheet-section">
+		<clay:sheet-section>
 			<h3 class="sheet-subtitle"><liferay-ui:message key="desktop" /></h3>
 
 			<aui:input helpMessage="allow-lan-syncing-help" label="allow-lan-syncing" name="lanEnabled" type="toggle-switch" value="<%= lanEnabled %>" />
@@ -112,17 +112,17 @@ if (deployed && oAuthEnabled) {
 					</aui:input>
 				</div>
 			</div>
-		</div>
+		</clay:sheet-section>
 
 		<aui:fieldset>
-			<div class="sheet-section">
+			<clay:sheet-section>
 				<h3 class="sheet-subtitle"><liferay-ui:message key="mobile" /></h3>
 
 				<aui:input helpMessage="force-security-mode-help" label="force-security-mode" name="forceSecurityMode" type="toggle-switch" value="<%= forceSecurityMode %>" />
-			</div>
+			</clay:sheet-section>
 		</aui:fieldset>
 
-		<div class="sheet-footer">
+		<clay:sheet-footer>
 			<div class="btn-group">
 				<div class="btn-group-item">
 					<clay:button
@@ -132,8 +132,8 @@ if (deployed && oAuthEnabled) {
 					/>
 				</div>
 			</div>
-		</div>
-	</div>
+		</clay:sheet-footer>
+	</clay:sheet>
 </aui:form>
 
 <aui:script>

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/add_uad_export_processes.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/add_uad_export_processes.jsp
@@ -40,8 +40,8 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 		<aui:input name="redirect" type="hidden" value="<%= viewUADExportProcesses.toString() %>" />
 		<aui:input name="applicationKeys" type="hidden" />
 
-		<div class="sheet sheet-lg">
-			<div class="sheet-section">
+		<clay:sheet>
+			<clay:sheet-section>
 				<h2 class="sheet-title"><liferay-ui:message key="export-personal-data" /></h2>
 
 				<div class="sheet-text">
@@ -122,14 +122,14 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 						searchResultCssClass="show-quick-actions-on-hover table table-autofit"
 					/>
 				</liferay-ui:search-container>
-			</div>
+			</clay:sheet-section>
 
-			<div class="sheet-footer">
+			<clay:sheet-footer>
 				<aui:button primary="<%= true %>" type="submit" value="export" />
 
 				<aui:button href="<%= backURL %>" type="cancel" />
-			</div>
-		</div>
+			</clay:sheet-footer>
+		</clay:sheet>
 	</aui:form>
 </clay:container-fluid>
 

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/anonymize_nonreviewable_uad_data.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/anonymize_nonreviewable_uad_data.jsp
@@ -38,16 +38,16 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 		<aui:input name="p_u_i_d" type="hidden" value="<%= String.valueOf(selectedUser.getUserId()) %>" />
 		<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
 
-		<div class="sheet sheet-lg">
-			<div class="sheet-header">
+		<clay:sheet>
+			<clay:sheet-header>
 				<h2 class="sheet-title"><liferay-ui:message key="auto-anonymize-data" /></h2>
-			</div>
+			</clay:sheet-header>
 
-			<div class="sheet-section">
+			<clay:sheet-section>
 				<div class="text-muted"><liferay-ui:message key="auto-anonymize-data-that-does-not-require-review" /></div>
-			</div>
+			</clay:sheet-section>
 
-			<div class="sheet-section">
+			<clay:sheet-section>
 				<h3 class="sheet-subtitle">
 					<liferay-ui:message key="status-summary" />
 				</h3>
@@ -65,9 +65,9 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 						<aui:button cssClass="btn-sm" disabled="<%= totalReviewableUADEntitiesCount == 0 %>" onClick='<%= renderResponse.getNamespace() + "confirmAction('nonreviewableUADDataForm', '" + anonymizeURL.toString() + "', '" + UnicodeLanguageUtil.get(request, "are-you-sure-you-want-to-anonymize-the-users-personal-data") + "')" %>' primary="true" value="anonymize" />
 					</div>
 				</div>
-			</div>
+			</clay:sheet-section>
 
-			<div class="sheet-section">
+			<clay:sheet-section>
 				<c:choose>
 					<c:when test="<%= totalReviewableUADEntitiesCount == 0 %>">
 						<liferay-ui:empty-result-message
@@ -117,8 +117,8 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 						</liferay-ui:search-container>
 					</c:otherwise>
 				</c:choose>
-			</div>
-		</div>
+			</clay:sheet-section>
+		</clay:sheet>
 	</aui:form>
 </clay:container-fluid>
 

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/review_uad_data.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/review_uad_data.jsp
@@ -185,20 +185,20 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 		<clay:col
 			lg="9"
 		>
-			<div class="sheet">
-				<div class="sheet-header">
+			<clay:sheet>
+				<clay:sheet-header>
 					<h2 class="sheet-title"><liferay-ui:message key="review-data" /></h2>
-				</div>
+				</clay:sheet-header>
 
-				<div class="sheet-section">
+				<clay:sheet-section>
 					<h3 class="sheet-subtitle">
 						<liferay-ui:message key="status-summary" />
 					</h3>
 
 					<strong><liferay-ui:message key="remaining-items" />: </strong><%= totalReviewableUADEntitiesCount %>
-				</div>
+				</clay:sheet-section>
 
-				<div class="sheet-section">
+				<clay:sheet-section>
 					<c:choose>
 						<c:when test="<%= totalReviewableUADEntitiesCount == 0 %>">
 							<liferay-ui:empty-result-message
@@ -211,8 +211,8 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 							<liferay-util:include page="/view_uad_entities.jsp" servletContext="<%= application %>" />
 						</c:otherwise>
 					</c:choose>
-				</div>
-			</div>
+				</clay:sheet-section>
+			</clay:sheet>
 		</clay:col>
 	</clay:row>
 </clay:container-fluid>


### PR DESCRIPTION
As part of our effort to Improve HTML Layout Generation Strategies in DXP, here a PR about changing autofit-* and sheet-* for clay:sheet* and clay:content*

LPS-114060:
Use new Layout Tags in JSPs in sync-web
- settings.jsp
How to test it: go to Sync web > Settings and review the sheet container is the same

LPS-114061
Use new Layout Tags in JSPs in user-associated-data-web
* add_uad_export_processes.jsp
* anonymize_nonreviewable_uad_data.jsp
* review_uad_data.jsp
How to test it: go to `user associated` and review the sheet container is pretty similar

LPS-114059
Use new Layout Tags in JSPs in staging-taglib
* content/page.jsp
* deletions/page.jsp
* permissions/page.jsp
* select_pages/page.jsp
How to test it: activate and go to `staging` and review all the application screens, all sheet container should be displayed correctly.

/cc @eduardoallegrini