### PR TITLE
LPS-114009 - Remove unneeded autofit-row use

### DIFF
--- a/modules/apps/analytics/analytics-settings-web/src/main/resources/META-INF/resources/add_channel.jsp
+++ b/modules/apps/analytics/analytics-settings-web/src/main/resources/META-INF/resources/add_channel.jsp
@@ -53,8 +53,10 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(resourceBundle, "
 <aui:form action="<%= addChannelURL %>" method="post" name="fm">
 	<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
 
-	<div class="portlet-analytics-settings sheet sheet-lg">
-		<h2 class="autofit-row">
+	<clay:sheet
+		className="portlet-analytics-settings"
+	>
+		<h2>
 			<liferay-ui:message key="new-property" />
 		</h2>
 
@@ -141,7 +143,7 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(resourceBundle, "
 				<aui:button disabled="<%= true %>" id="add-channel-button" type="submit" value="done" />
 			</aui:button-row>
 		</div>
-	</div>
+	</clay:sheet>
 </aui:form>
 
 <aui:script use="liferay-search-container">

--- a/modules/apps/analytics/analytics-settings-web/src/main/resources/META-INF/resources/edit_channel.jsp
+++ b/modules/apps/analytics/analytics-settings-web/src/main/resources/META-INF/resources/edit_channel.jsp
@@ -57,8 +57,10 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(resourceBundle, "
 	<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
 	<aui:input name="channelId" type="hidden" value="<%= channelId %>" />
 
-	<div class="portlet-analytics-settings sheet sheet-lg">
-		<h2 class="autofit-row">
+	<clay:sheet
+		className="portlet-analytics-settings"
+	>
+		<h2>
 			<liferay-ui:message arguments="<%= channelName %>" key="sites-to-sync-x" />
 		</h2>
 
@@ -127,5 +129,5 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(resourceBundle, "
 				<aui:button type="submit" value="done" />
 			</aui:button-row>
 		</div>
-	</div>
+	</clay:sheet>
 </aui:form>

--- a/modules/apps/analytics/analytics-settings-web/src/main/resources/META-INF/resources/edit_properties.jsp
+++ b/modules/apps/analytics/analytics-settings-web/src/main/resources/META-INF/resources/edit_properties.jsp
@@ -32,7 +32,9 @@ if (!Validator.isBlank(analyticsConfiguration.token())) {
 String keywords = ParamUtil.getString(request, "keywords");
 %>
 
-<div class="pb-2 portlet-analytics-settings sheet sheet-lg">
+<clay:sheet
+	className="pb-2 portlet-analytics-settings"
+>
 	<h2>
 		<liferay-ui:message key="sync-sites-to-property" />
 	</h2>
@@ -130,4 +132,4 @@ String keywords = ParamUtil.getString(request, "keywords");
 			</liferay-ui:search-container>
 		</c:otherwise>
 	</c:choose>
-</div>
+</clay:sheet>

--- a/modules/apps/analytics/analytics-settings-web/src/main/resources/META-INF/resources/edit_sites.jsp
+++ b/modules/apps/analytics/analytics-settings-web/src/main/resources/META-INF/resources/edit_sites.jsp
@@ -30,11 +30,9 @@ GroupDisplayContext groupDisplayContext = new GroupDisplayContext("/analytics/ed
 
 <portlet:actionURL name="/analytics/edit_synced_sites" var="editSyncedSitesURL" />
 
-<div class="sheet sheet-lg">
-	<h2 class="autofit-row">
-		<span class="autofit-col autofit-col-expand">
-			<liferay-ui:message key="choose-sites-to-sync" />
-		</span>
+<clay:sheet>
+	<h2>
+		<liferay-ui:message key="choose-sites-to-sync" />
 	</h2>
 
 	<clay:management-toolbar
@@ -78,4 +76,4 @@ GroupDisplayContext groupDisplayContext = new GroupDisplayContext("/analytics/ed
 			<aui:button disabled="<%= !connected %>" type="submit" value="save-and-sync" />
 		</aui:button-row>
 	</aui:form>
-</div>
+</clay:sheet>

--- a/modules/apps/analytics/analytics-settings-web/src/main/resources/META-INF/resources/edit_synced_contacts.jsp
+++ b/modules/apps/analytics/analytics-settings-web/src/main/resources/META-INF/resources/edit_synced_contacts.jsp
@@ -33,11 +33,11 @@ Set<String> syncedUserGroupIds = SetUtil.fromArray(analyticsConfiguration.synced
 
 <portlet:actionURL name="/analytics/edit_synced_contacts" var="editSyncedContactsURL" />
 
-<div class="portlet-analytics-settings sheet sheet-lg">
-	<h2 class="autofit-row">
-		<span class="autofit-col autofit-col-expand">
-			<liferay-ui:message key="contact-data" />
-		</span>
+<clay:sheet
+	className="portlet-analytics-settings"
+>
+	<h2>
+		<liferay-ui:message key="contact-data" />
 	</h2>
 
 	<aui:form action="<%= editSyncedContactsURL %>" method="post" name="fm">
@@ -162,4 +162,4 @@ Set<String> syncedUserGroupIds = SetUtil.fromArray(analyticsConfiguration.synced
 			<aui:button disabled="<%= !connected %>" type="submit" value="save" />
 		</aui:button-row>
 	</aui:form>
-</div>
+</clay:sheet>

--- a/modules/apps/analytics/analytics-settings-web/src/main/resources/META-INF/resources/edit_synced_contacts_groups.jsp
+++ b/modules/apps/analytics/analytics-settings-web/src/main/resources/META-INF/resources/edit_synced_contacts_groups.jsp
@@ -50,19 +50,15 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(resourceBundle, "
 	</clay:row>
 </clay:container-fluid>
 
-<div class="sheet sheet-lg">
-	<h2 class="autofit-row">
-		<span class="autofit-col autofit-col-expand">
-			<liferay-ui:message key="select-contacts-by-user-groups" />
-		</span>
+<clay:sheet>
+	<h2>
+		<liferay-ui:message key="select-contacts-by-user-groups" />
 	</h2>
 
 	<hr />
 
-	<div class="autofit-row form-text">
-		<span class="autofit-col autofit-col-expand pb-3">
-			<liferay-ui:message key="select-contacts-by-user-groups-help" />
-		</span>
+	<div class="c-pb-3 form-text">
+		<liferay-ui:message key="select-contacts-by-user-groups-help" />
 	</div>
 
 	<%
@@ -106,4 +102,4 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(resourceBundle, "
 			<aui:button href="<%= redirect %>" type="cancel" value="cancel" />
 		</aui:button-row>
 	</aui:form>
-</div>
+</clay:sheet>

--- a/modules/apps/analytics/analytics-settings-web/src/main/resources/META-INF/resources/edit_synced_contacts_organizations.jsp
+++ b/modules/apps/analytics/analytics-settings-web/src/main/resources/META-INF/resources/edit_synced_contacts_organizations.jsp
@@ -50,19 +50,15 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(resourceBundle, "
 	</clay:row>
 </clay:container-fluid>
 
-<div class="sheet sheet-lg">
-	<h2 class="autofit-row">
-		<span class="autofit-col autofit-col-expand">
-			<liferay-ui:message key="select-contacts-by-organizations" />
-		</span>
+<clay:sheet>
+	<h2>
+		<liferay-ui:message key="select-contacts-by-organizations" />
 	</h2>
 
 	<hr />
 
-	<div class="autofit-row form-text">
-		<span class="autofit-col autofit-col-expand pb-3">
-			<liferay-ui:message key="select-contacts-by-organizations-help" />
-		</span>
+	<div class="c-pb-3 form-text">
+		<liferay-ui:message key="select-contacts-by-organizations-help" />
 	</div>
 
 	<%
@@ -106,4 +102,4 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(resourceBundle, "
 			<aui:button href="<%= redirect %>" type="cancel" value="cancel" />
 		</aui:button-row>
 	</aui:form>
-</div>
+</clay:sheet>

--- a/modules/apps/analytics/analytics-settings-web/src/main/resources/META-INF/resources/edit_workspace_connection.jsp
+++ b/modules/apps/analytics/analytics-settings-web/src/main/resources/META-INF/resources/edit_workspace_connection.jsp
@@ -60,7 +60,7 @@ if (analyticsConfiguration != null) {
 
 <portlet:actionURL name="/analytics/edit_workspace_connection" var="editWorkspaceConnectionURL" />
 
-<div class="sheet sheet-lg">
+<clay:sheet>
 	<c:if test="<%= AnalyticsSettingsUtil.isAnalyticsEnabledWithOAuth(themeDisplay.getCompanyId()) %>">
 		<aui:alert type="warning">
 			<div class="mb-2">
@@ -79,10 +79,8 @@ if (analyticsConfiguration != null) {
 		</aui:alert>
 	</c:if>
 
-	<h2 class="autofit-row">
-		<span class="autofit-col autofit-col-expand">
-			<liferay-ui:message key="connect-analytics-cloud" />
-		</span>
+	<h2>
+		<liferay-ui:message key="connect-analytics-cloud" />
 	</h2>
 
 	<aui:form action="<%= editWorkspaceConnectionURL %>" data-senna-off="true" method="post" name="fm" onSubmit='<%= renderResponse.getNamespace() + "confirmation(event);" %>'>
@@ -177,7 +175,7 @@ if (analyticsConfiguration != null) {
 			<aui:button disabled="<%= !connected %>" href="<%= selectSitesURL.toString() %>" primary="<%= true %>" value="select-sites" />
 		</aui:button-row>
 	</aui:fieldset>
-</div>
+</clay:sheet>
 
 <script>
 	function <portlet:namespace />confirmation(event) {

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/layout/view.jsp
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/layout/view.jsp
@@ -35,8 +35,12 @@ if (mvcPath.startsWith("/edit_entry.jsp")) {
 		<clay:container-fluid
 			className="p-0"
 		>
-			<div class="app-builder-standalone-menu autofit-row">
-				<div class="autofit-col autofit-col-expand">
+			<clay:content-row
+				className="app-builder-standalone-menu"
+			>
+				<clay:content-col
+					expand="true"
+				>
 					<a class="company-link" href="<%= PortalUtil.addPreservedParameters(themeDisplay, themeDisplay.getURLPortal(), false, true) %>">
 						<span class="company-details text-truncate">
 							<img alt="" class="company-logo" src='<%= themeDisplay.getPathImage() + "/company_logo?img_id=" + company.getLogoId() + "&t=" + WebServerServletTokenUtil.getToken(company.getLogoId()) %>' />
@@ -44,7 +48,7 @@ if (mvcPath.startsWith("/edit_entry.jsp")) {
 							<span class="company-name"><%= HtmlUtil.escape(company.getName()) %></span>
 						</span>
 					</a>
-				</div>
+				</clay:content-col>
 
 				<div style="display: none;">
 					<liferay-portlet:runtime
@@ -52,13 +56,15 @@ if (mvcPath.startsWith("/edit_entry.jsp")) {
 					/>
 				</div>
 
-				<div class="autofit-col text-right">
+				<clay:content-col
+					className="text-right"
+				>
 					<liferay-portlet:runtime
 						portletProviderAction="<%= PortletProvider.Action.VIEW %>"
 						portletProviderClassName="com.liferay.admin.kernel.util.PortalUserPersonalBarApplicationType$UserPersonalBar"
 					/>
-				</div>
-			</div>
+				</clay:content-col>
+			</clay:content-row>
 
 			<h1 class="app-builder-standalone-name <%= editEntryCssClass %>"><%= HtmlUtil.escape(appName) %></h1>
 		</clay:container-fluid>

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/view_content.jsp
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/view_content.jsp
@@ -57,15 +57,21 @@ RankingResultContentDisplayContext rankingResultContentDisplayContext = rankingR
 >
 	<c:choose>
 		<c:when test="<%= rankingResultContentDisplayContext.isVisible() %>">
-			<div class="result-rankings-view-content-container sheet sheet-lg">
-				<div class="autofit-row">
-					<div class="autofit-col autofit-col-expand">
+			<clay:sheet
+				className="result-rankings-view-content-container"
+			>
+				<clay:content-row>
+					<clay:content-col
+						expand="true"
+					>
 						<div class="sheet-title">
 							<%= rankingResultContentDisplayContext.getHeaderTitle() %>
 						</div>
-					</div>
+					</clay:content-col>
 
-					<div class="autofit-col visible-interaction">
+					<clay:content-col
+						className="visible-interaction"
+					>
 						<c:if test="<%= rankingResultContentDisplayContext.hasEditPermission() %>">
 							<div class="asset-actions lfr-meta-actions">
 
@@ -92,15 +98,15 @@ RankingResultContentDisplayContext rankingResultContentDisplayContext = rankingR
 								/>
 							</div>
 						</c:if>
-					</div>
-				</div>
+					</clay:content-col>
+				</clay:content-row>
 
 				<liferay-asset:asset-display
 					assetEntry="<%= rankingResultContentDisplayContext.getAssetEntry() %>"
 					assetRenderer="<%= rankingResultContentDisplayContext.getAssetRenderer() %>"
 					assetRendererFactory="<%= rankingResultContentDisplayContext.getAssetRendererFactory() %>"
 				/>
-			</div>
+			</clay:sheet>
 		</c:when>
 		<c:otherwise>
 			<div class="alert alert-danger">

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/edit_kaleo_definition_version.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/edit_kaleo_definition_version.jsp
@@ -149,14 +149,12 @@ String successMessageKey = KaleoDesignerPortletKeys.KALEO_DESIGNER + "requestPro
 						</div>
 
 						<div class="sidebar-header">
-							<div class="autofit-row sidebar-section">
-								<div class="autofit-col autofit-col-expand">
-									<h4 class="component-title">
-										<span class="text-truncate-inline">
-											<span class="text-truncate"><%= HtmlUtil.escape(kaleoDefinitionVersion.getTitle(locale)) %></span>
-										</span>
-									</h4>
-								</div>
+							<div class="sidebar-section">
+								<h4 class="component-title">
+									<span class="text-truncate-inline">
+										<span class="text-truncate"><%= HtmlUtil.escape(kaleoDefinitionVersion.getTitle(locale)) %></span>
+									</span>
+								</h4>
 							</div>
 						</div>
 


### PR DESCRIPTION
As part of our effort to Improve HTML Layout Generation Strategies in DXP, here a PR about changing autofit-* and sheet-* for clay:sheet* and clay:content*

This "PR" updates markup with new taglibs. What we expect is to see the same visual design, so no visual changes are required.
The way to validate the changes is to see the same visual result. if is there any previously agreed difference it would be correctly pointed in comments

LPS-114005
Use new Layout Tags in JSPs in analytics-settings-web
Validate by reviewing add an edit pages in analytics settings module

LPS-114006
Use new Layout Tags in JSPs in app-builder-web
Validate by reviewing app builder stand-alone front page

LPS-114007
Use new Layout Tags in JSPs in portal-search-tuning-web
Validate by reviewing Result rankings sheet in DXP Search tuning rankings

LPS-114009
Use new Layout Tags in JSPs in portal-workflow-kaleo-designer-web
Validate by reviewing Kaleo definition version page