### PR TITLE
LPS-114014 - Apply the use of sheet and autofit clay taglib in change-tracking-web

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/edit_calendar_booking.jsp
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/edit_calendar_booking.jsp
@@ -275,7 +275,7 @@ while (manageableCalendarsIterator.hasNext()) {
 	<aui:input name="workflowAction" type="hidden" value="<%= WorkflowConstants.ACTION_PUBLISH %>" />
 
 	<div class="lfr-form-content">
-		<div class="sheet sheet-lg">
+		<clay:sheet>
 			<liferay-ui:error exception="<%= CalendarBookingDurationException.class %>" message="please-enter-a-start-date-that-comes-before-the-end-date" />
 			<liferay-ui:error exception="<%= CalendarBookingRecurrenceException.class %>" message="the-last-repeating-date-should-come-after-the-event-start-date" />
 
@@ -508,7 +508,7 @@ while (manageableCalendarsIterator.hasNext()) {
 			</aui:fieldset>
 
 			<%@ include file="/calendar_booking_recurrence_container.jspf" %>
-		</div>
+		</clay:sheet>
 	</div>
 
 	<aui:button-row cssClass="d-block">

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists/edit_ct_collection.jsp
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists/edit_ct_collection.jsp
@@ -61,7 +61,7 @@ portletDisplay.setShowBackIcon(true);
 <liferay-ui:error exception="<%= CTCollectionDescriptionException.class %>" message="the-publication-description-is-too-long" />
 <liferay-ui:error exception="<%= CTCollectionNameException.class %>" message="the-publication-name-is-too-long" />
 
-<div class="custom-sheet sheet sheet-lg">
+<clay:sheet>
 	<aui:form action='<%= actionURL + "&etag=0&strip=0" %>' cssClass="lfr-export-dialog" method="post" name="editChangeListFm">
 		<aui:input name="ctCollectionId" type="hidden" value="<%= ctCollectionId %>" />
 
@@ -93,4 +93,4 @@ portletDisplay.setShowBackIcon(true);
 			<aui:button href="<%= redirect %>" type="cancel" />
 		</aui:button-row>
 	</aui:form>
-</div>
+</clay:sheet>

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists/view_conflicts.jsp
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists/view_conflicts.jsp
@@ -81,71 +81,79 @@ portletDisplay.setURLBack(backURL);
 
 					<tr>
 						<td>
-							<div class="autofit-row">
-								<div class="autofit-col user-portrait-wrapper">
+							<clay:content-row>
+								<clay:content-col
+									className="user-portrait-wrapper"
+								>
 									<liferay-ui:user-portrait
 										userId="<%= ctEntry.getUserId() %>"
 									/>
-								</div>
+								</clay:content-col>
 
-								<div class="autofit-col-expand">
+								<clay:content-col
+									expand="true"
+								>
 									<p class="entry-title text-muted"><%= HtmlUtil.escape(ctDisplayRendererRegistry.getEntryDescription(request, ctEntry)) %></p>
 
 									<div>
-										<div class="alert alert-success autofit-row" role="alert">
-											<div class="autofit-col autofit-col-expand">
-												<div class="autofit-section">
-													<span class="alert-indicator">
-														<aui:icon image="check-circle-full" markupView="lexicon" />
-													</span>
+										<div class="alert alert-success" role="alert">
+											<clay:content-row>
+												<clay:content-col
+													expand="true"
+												>
+													<clay:content-section>
+														<span class="alert-indicator">
+															<aui:icon image="check-circle-full" markupView="lexicon" />
+														</span>
 
-													<%
-													ResourceBundle conflictInfoResourceBundle = conflictInfo.getResourceBundle(locale);
-													%>
+														<%
+														ResourceBundle conflictInfoResourceBundle = conflictInfo.getResourceBundle(locale);
+														%>
 
-													<strong class="lead">
-														<%= conflictInfo.getConflictDescription(conflictInfoResourceBundle) + ":" %>
-													</strong>
-													<%= conflictInfo.getResolutionDescription(conflictInfoResourceBundle) %>
-												</div>
-											</div>
+														<strong class="lead">
+															<%= conflictInfo.getConflictDescription(conflictInfoResourceBundle) + ":" %>
+														</strong>
+														<%= conflictInfo.getResolutionDescription(conflictInfoResourceBundle) %>
+													</clay:content-section>
+												</clay:content-col>
 
-											<liferay-portlet:actionURL name="/change_lists/delete_ct_auto_resolution_info" var="dismissURL">
-												<liferay-portlet:param name="redirect" value="<%= currentURL %>" />
-												<liferay-portlet:param name="ctAutoResolutionInfoId" value="<%= String.valueOf(conflictInfo.getCTAutoResolutionInfoId()) %>" />
-											</liferay-portlet:actionURL>
+												<liferay-portlet:actionURL name="/change_lists/delete_ct_auto_resolution_info" var="dismissURL">
+													<liferay-portlet:param name="redirect" value="<%= currentURL %>" />
+													<liferay-portlet:param name="ctAutoResolutionInfoId" value="<%= String.valueOf(conflictInfo.getCTAutoResolutionInfoId()) %>" />
+												</liferay-portlet:actionURL>
 
-											<div class="autofit-col">
-												<div class="autofit-section">
-													<a class="btn btn-secondary btn-sm" href="<%= dismissURL %>" type="button">
-														<liferay-ui:message key="dismiss" />
-													</a>
-												</div>
-											</div>
-
-											<%
-											boolean viewDiff = false;
-
-											if (conflictInfo.getSourcePrimaryKey() == conflictInfo.getTargetPrimaryKey()) {
-												viewDiff = true;
-											}
-
-											String viewURL = ctDisplayRendererRegistry.getViewURL(liferayPortletRequest, liferayPortletResponse, ctEntry, viewDiff);
-											%>
-
-											<c:if test="<%= Validator.isNotNull(viewURL) %>">
-												<div class="autofit-col">
-													<div class="autofit-section">
-														<a class="btn btn-secondary btn-sm" href="<%= viewURL %>" type="button">
-															<liferay-ui:message key="view" />
+												<clay:content-col>
+													<clay:content-section>
+														<a class="btn btn-secondary btn-sm" href="<%= dismissURL %>" type="button">
+															<liferay-ui:message key="dismiss" />
 														</a>
-													</div>
-												</div>
-											</c:if>
+													</clay:content-section>
+												</clay:content-col>
+
+												<%
+												boolean viewDiff = false;
+
+												if (conflictInfo.getSourcePrimaryKey() == conflictInfo.getTargetPrimaryKey()) {
+													viewDiff = true;
+												}
+
+												String viewURL = ctDisplayRendererRegistry.getViewURL(liferayPortletRequest, liferayPortletResponse, ctEntry, viewDiff);
+												%>
+
+												<c:if test="<%= Validator.isNotNull(viewURL) %>">
+													<clay:content-col>
+														<clay:content-section>
+															<a class="btn btn-secondary btn-sm" href="<%= viewURL %>" type="button">
+																<liferay-ui:message key="view" />
+															</a>
+														</clay:content-section>
+													</clay:content-col>
+												</c:if>
+											</clay:content-row>
 										</div>
 									</div>
-								</div>
-							</div>
+								</clay:content-col>
+							</clay:content-row>
 						</td>
 					</tr>
 
@@ -179,76 +187,84 @@ portletDisplay.setURLBack(backURL);
 
 					<tr>
 						<td>
-							<div class="autofit-row">
-								<div class="autofit-col user-portrait-wrapper">
+							<clay:content-row>
+								<clay:content-col
+									className="user-portrait-wrapper"
+								>
 									<liferay-ui:user-portrait
 										userId="<%= ctEntry.getUserId() %>"
 									/>
-								</div>
+								</clay:content-col>
 
-								<div class="autofit-col-expand">
+								<clay:content-col
+									expand="true"
+								>
 									<p class="entry-title text-muted"><%= HtmlUtil.escape(ctDisplayRendererRegistry.getEntryDescription(request, ctEntry)) %></p>
 
 									<div>
-										<div class="alert alert-warning autofit-row" role="alert">
-											<div class="autofit-col autofit-col-expand">
-												<div class="autofit-section">
-													<span class="alert-indicator">
-														<aui:icon image="warning-full" markupView="lexicon" />
-													</span>
+										<div class="alert alert-warning" role="alert">
+											<clay:content-row>
+												<clay:content-col
+													expand="true"
+												>
+													<clay:content-section>
+														<span class="alert-indicator">
+															<aui:icon image="warning-full" markupView="lexicon" />
+														</span>
 
-													<%
-													ResourceBundle conflictInfoResourceBundle = conflictInfo.getResourceBundle(locale);
-													%>
+														<%
+														ResourceBundle conflictInfoResourceBundle = conflictInfo.getResourceBundle(locale);
+														%>
 
-													<strong class="lead">
-														<%= conflictInfo.getConflictDescription(conflictInfoResourceBundle) + ":" %>
-													</strong>
-													<%= conflictInfo.getResolutionDescription(conflictInfoResourceBundle) %>
-												</div>
-											</div>
+														<strong class="lead">
+															<%= conflictInfo.getConflictDescription(conflictInfoResourceBundle) + ":" %>
+														</strong>
+														<%= conflictInfo.getResolutionDescription(conflictInfoResourceBundle) %>
+													</clay:content-section>
+												</clay:content-col>
 
-											<%
-											String editURL = ctDisplayRendererRegistry.getEditURL(request, ctEntry);
-											%>
+												<%
+												String editURL = ctDisplayRendererRegistry.getEditURL(request, ctEntry);
+												%>
 
-											<c:choose>
-												<c:when test="<%= Validator.isNotNull(editURL) %>">
-													<div class="autofit-col">
-														<div class="autofit-section">
-															<a class="btn btn-secondary btn-sm" href="<%= editURL %>" type="button">
-																<liferay-ui:message key="edit" />
-															</a>
-														</div>
-													</div>
-												</c:when>
-												<c:otherwise>
-
-													<%
-													boolean viewDiff = false;
-
-													if (conflictInfo.getSourcePrimaryKey() == conflictInfo.getTargetPrimaryKey()) {
-														viewDiff = true;
-													}
-
-													String viewURL = ctDisplayRendererRegistry.getViewURL(liferayPortletRequest, liferayPortletResponse, ctEntry, viewDiff);
-													%>
-
-													<c:if test="<%= Validator.isNotNull(viewURL) %>">
+												<c:choose>
+													<c:when test="<%= Validator.isNotNull(editURL) %>">
 														<div class="autofit-col">
 															<div class="autofit-section">
-																<a class="btn btn-secondary btn-sm" href="<%= viewURL %>" type="button">
-																	<liferay-ui:message key="view" />
+																<a class="btn btn-secondary btn-sm" href="<%= editURL %>" type="button">
+																	<liferay-ui:message key="edit" />
 																</a>
 															</div>
 														</div>
-													</c:if>
-												</c:otherwise>
-											</c:choose>
+													</c:when>
+													<c:otherwise>
+
+														<%
+														boolean viewDiff = false;
+
+														if (conflictInfo.getSourcePrimaryKey() == conflictInfo.getTargetPrimaryKey()) {
+															viewDiff = true;
+														}
+
+														String viewURL = ctDisplayRendererRegistry.getViewURL(liferayPortletRequest, liferayPortletResponse, ctEntry, viewDiff);
+														%>
+
+														<c:if test="<%= Validator.isNotNull(viewURL) %>">
+															<clay:content-col>
+																<clay:content-section>
+																	<a class="btn btn-secondary btn-sm" href="<%= viewURL %>" type="button">
+																		<liferay-ui:message key="view" />
+																	</a>
+																</clay:content-section>
+															</clay:content-col>
+														</c:if>
+													</c:otherwise>
+												</c:choose>
+											</clay:content-row>
 										</div>
 									</div>
-								</div>
-							</div>
+								</clay:content-col>
+							</clay:content-row>
 						</td>
 					</tr>
 

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists_configuration/global_settings.jspf
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists_configuration/global_settings.jspf
@@ -14,11 +14,11 @@
  */
 --%>
 
-<div class="sheet-header">
+<clay:sheet-header>
 	<h2 class="sheet-title"><liferay-ui:message key="global-settings" /></h2>
-</div>
+</clay:sheet-header>
 
-<div class="sheet-section">
+<clay:sheet-section>
 	<h3 class="sheet-subtitle"><liferay-ui:message key="enable-change-lists" /></h3>
 
 	<div class="sheet-text"><liferay-ui:message key="change-lists-help" /></div>
@@ -26,13 +26,13 @@
 	<div class="form-group">
 		<aui:input label="" name="enableChangeLists" onClick='<%= renderResponse.getNamespace() + "updateSubmitRedirectToOverview()" %>' type="toggle-switch" value="<%= changeListsConfigurationDisplayContext.isChangeListsEnabled() %>" />
 	</div>
-</div>
+</clay:sheet-section>
 
-<div class="sheet-footer">
+<clay:sheet-footer>
 	<aui:button primary="<%= true %>" type="submit" value="submit" />
 
 	<aui:button disabled="<%= !changeListsConfigurationDisplayContext.isChangeListsEnabled() %>" name="submitRedirectToOverview" onClick='<%= renderResponse.getNamespace() + "doSubmitRedirectToOverview()" %>' primary="<%= false %>" type="submit" value="save-and-go-to-overview" />
-</div>
+</clay:sheet-footer>
 
 <script>
 	function <portlet:namespace />doSubmitRedirectToOverview() {

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists_configuration/view.jsp
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists_configuration/view.jsp
@@ -23,8 +23,8 @@
 		<aui:input name="navigation" type="hidden" value="<%= changeListsConfigurationDisplayContext.getNavigation() %>" />
 		<aui:input name="redirectToOverview" type="hidden" value="<%= false %>" />
 
-		<div class="sheet sheet-lg">
+		<clay:sheet>
 			<%@ include file="/change_lists_configuration/global_settings.jspf" %>
-		</div>
+		</clay:sheet>
 	</aui:form>
 </clay:container-fluid>


### PR DESCRIPTION
As part of our effort to Improve HTML Layout Generation Strategies in DXP, here a PR about changing autofit-* and sheet-* for clay:sheet* and clay:content*

This "PR" updates markup with new taglibs. What we expect is to see the same visual design, so no visual changes are required.
The way to validate the changes is to see the same visual result. if is there any previously agreed difference it would be correctly pointed in comments

LPS-114013
Use new Layout Tags in JSPs in change-tracking-web
Validate by reviewing edit calendar booking page in change-tracking-web module

LPS-114014
Use new Layout Tags in JSPs in change-tracking-web
Validate by reviewing edit ct collection page


Tests passed:
https://github.com/marcoscv-work/liferay-portal/pull/328