### PR TITLE
LPS-114030 - Apply the use of sheet clay taglib in expando-web

### DIFF
--- a/modules/apps/expando/expando-web/src/main/resources/META-INF/resources/edit/select_field_type.jsp
+++ b/modules/apps/expando/expando-web/src/main/resources/META-INF/resources/edit/select_field_type.jsp
@@ -60,11 +60,11 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(request, "new-cus
 
 <liferay-frontend:edit-form>
 	<liferay-frontend:edit-form-body>
-		<div class="sheet-header">
+		<clay:sheet-header>
 			<h2 class="sheet-title">
 				<liferay-ui:message key="new-custom-field" />
 			</h2>
-		</div>
+		</clay:sheet-header>
 
 		<clay:row
 			className="clay-site-row-spacer"

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/publish/publish_layouts.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/publish/publish_layouts.jsp
@@ -239,11 +239,11 @@ response.setHeader("Ajax-ID", request.getHeader("Ajax-ID"));
 						</aui:fieldset>
 
 						<aui:fieldset cssClass="options-group">
-							<div class="sheet-section">
+							<clay:sheet-section>
 								<h3 class="sheet-subtitle"><liferay-ui:message key="date" /></h3>
 
 								<%@ include file="/publish/publish_layouts_scheduler.jspf" %>
-							</div>
+							</clay:sheet-section>
 						</aui:fieldset>
 
 						<liferay-staging:deletions

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/publish/view.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/publish/view.jsp
@@ -127,8 +127,12 @@ simplePublishURL.setParameter("targetGroupId", String.valueOf(liveGroupId));
 	<clay:container-fluid
 		className="publish-navbar"
 	>
-		<div class="autofit-row autofit-row-center">
-			<div class="autofit-col autofit-col-expand">
+		<clay:content-row
+			verticalAlign="center"
+		>
+			<clay:content-col
+				expand="true"
+			>
 				<clay:navigation-bar
 					navigationItems='<%=
 						new JSPNavigationItemList(pageContext) {
@@ -151,17 +155,17 @@ simplePublishURL.setParameter("targetGroupId", String.valueOf(liveGroupId));
 						}
 					%>'
 				/>
-			</div>
+			</clay:content-col>
 
-			<div class="autofit-col">
+			<clay:content-col>
 				<clay:link
 					buttonStyle="link"
 					elementClasses="btn-sm"
 					href="<%= simplePublishURL.toString() %>"
 					label='<%= LanguageUtil.get(request, "switch-to-simple-publication") %>'
 				/>
-			</div>
-		</div>
+			</clay:content-col>
+		</clay:content-row>
 	</clay:container-fluid>
 </c:if>
 


### PR DESCRIPTION
As part of our effort to Improve HTML Layout Generation Strategies in DXP, here a PR about changing autofit-* and sheet-* for clay:sheet* and clay:content*

This "PR" updates markup with new taglibs. What we expect is to see the same visual design, so no visual changes are required.
The way to validate the changes is to see the same visual result. if is there any previously agreed difference it would be correctly pointed in comments

LPS-114031
Use new Layout Tags in JSPs in export-import-web
Review sheet visual design in select field type screen

LPS-114030
Apply the use of sheet clay taglib in expando-web
Validate by reviewing publish layout and portlet view


Tests passed here:
https://github.com/marcoscv-work/liferay-portal/pull/329