### PR TITLE
LPS-114055 Replace layout classes with new clay taglibs in site-navigation-admin-web

### DIFF
--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/domains.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/domains.jsp
@@ -40,12 +40,15 @@ List<String> domains = accountEntryDisplay.getDomains();
 		cssClass="sheet-subtitle"
 	>
 		<clay:content-col
+			containerElement="span"
 			expand="true"
 		>
 			<span class="heading-text"><liferay-ui:message key="valid-domains" /></span>
 		</clay:content-col>
 
-		<clay:content-col>
+		<clay:content-col
+			containerElement="span"
+		>
 			<span class="heading-end">
 				<liferay-ui:icon
 					cssClass="modify-link"

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/parent_account_entry.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/parent_account_entry.jsp
@@ -44,12 +44,15 @@ if (accountEntryDisplay.getAccountEntryId() > 0) {
 		cssClass="sheet-subtitle"
 	>
 		<clay:content-col
+			containerElement="span"
 			expand="true"
 		>
 			<span class="heading-text"><liferay-ui:message key="parent-account" /></span>
 		</clay:content-col>
 
-		<clay:content-col>
+		<clay:content-col
+			containerElement="span"
+		>
 			<span class="heading-end">
 				<liferay-ui:icon
 					cssClass="modify-link"

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/account_user/account_entries.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/account_user/account_entries.jsp
@@ -60,6 +60,7 @@ portletDisplay.setURLBack(backURL);
 			cssClass="sheet-subtitle"
 		>
 			<clay:content-col
+				containerElement="span"
 				expand="true"
 			>
 				<span class="heading-text">
@@ -67,7 +68,9 @@ portletDisplay.setURLBack(backURL);
 				</span>
 			</clay:content-col>
 
-			<clay:content-col>
+			<clay:content-col
+				containerElement="span"
+			>
 				<span class="heading-end">
 					<liferay-ui:icon
 						cssClass="modify-link"

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry.jsp
@@ -50,14 +50,18 @@ renderResponse.setTitle(assetListDisplayContext.getAssetListEntryTitle());
 
 						<c:choose>
 							<c:when test="<%= assetEntryListSegmentsEntryRels.size() > 1 %>">
-								<div class="autofit-row autofit-row-center">
-									<div class="autofit-col autofit-col-expand">
+								<clay:content-row
+									verticalAlign="center"
+								>
+									<clay:content-col
+										expand="true"
+									>
 										<strong class="text-uppercase">
 											<liferay-ui:message key="personalized-variations" />
 										</strong>
-									</div>
+									</clay:content-col>
 
-									<div class="autofit-col autofit-col-end">
+									<clay:content-col>
 										<ul class="navbar-nav">
 											<li>
 												<c:if test="<%= availableSegmentsEntries.size() > 0 %>">
@@ -71,8 +75,8 @@ renderResponse.setTitle(assetListDisplayContext.getAssetListEntryTitle());
 												</c:if>
 											</li>
 										</ul>
-									</div>
-								</div>
+									</clay:content-col>
+								</clay:content-row>
 
 								<ul class="nav nav-stacked">
 

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry_dynamic.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry_dynamic.jsp
@@ -48,15 +48,19 @@ AssetListEntry assetListEntry = assetListDisplayContext.getAssetListEntry();
 
 	<liferay-frontend:edit-form-body>
 		<h3 class="sheet-title">
-			<div class="autofit-row autofit-row-center">
-				<div class="autofit-col">
+			<clay:content-row
+				verticalAlign="center"
+			>
+				<clay:content-col>
 					<%= HtmlUtil.escape(editAssetListDisplayContext.getSegmentsEntryName(editAssetListDisplayContext.getSegmentsEntryId(), locale)) %>
-				</div>
+				</clay:content-col>
 
-				<div class="autofit-col autofit-col-end inline-item-after">
+				<clay:content-col
+					cssClass="inline-item-after"
+				>
 					<liferay-util:include page="/asset_list_entry_variation_action.jsp" servletContext="<%= application %>" />
-				</div>
-			</div>
+				</clay:content-col>
+			</clay:content-row>
 		</h3>
 
 		<liferay-frontend:form-navigator

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry_manual.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry_manual.jsp
@@ -34,25 +34,38 @@
 
 	<liferay-frontend:edit-form-body>
 		<h3 class="sheet-title">
-			<div class="autofit-row autofit-row-center">
-				<div class="autofit-col">
+			<clay:content-row
+				verticalAlign="center"
+			>
+				<clay:content-col>
 					<%= HtmlUtil.escape(editAssetListDisplayContext.getSegmentsEntryName(editAssetListDisplayContext.getSegmentsEntryId(), locale)) %>
-				</div>
+				</clay:content-col>
 
-				<div class="autofit-col autofit-col-end inline-item-after">
+				<clay:content-col
+					cssClass="inline-item-after"
+				>
 					<liferay-util:include page="/asset_list_entry_variation_action.jsp" servletContext="<%= application %>" />
-				</div>
-			</div>
+				</clay:content-col>
+			</clay:content-row>
 		</h3>
 
 		<h3 class="sheet-title text-uppercase">
-			<span class="autofit-padded-no-gutters autofit-row">
-				<span class="autofit-col autofit-col-expand">
+			<clay:content-row
+				containerElement="span"
+				noGutters="true"
+			>
+				<clay:content-col
+					containerElement="span"
+					expand="true"
+				>
 					<span class="heading-text">
 						<liferay-ui:message key="asset-entries" />
 					</span>
-				</span>
-				<span class="autofit-col">
+				</clay:content-col>
+
+				<clay:content-col
+					containerElement="span"
+				>
 					<liferay-ui:icon-menu
 						direction="right"
 						message="select"
@@ -80,8 +93,8 @@
 						%>
 
 					</liferay-ui:icon-menu>
-				</span>
-			</span>
+				</clay:content-col>
+			</clay:content-row>
 		</h3>
 
 		<liferay-ui:search-container

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/view_asset_list_entry_usages.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/view_asset_list_entry_usages.jsp
@@ -105,7 +105,7 @@ renderResponse.setTitle(assetListDisplayContext.getAssetListEntryTitle());
 		<clay:col
 			lg="9"
 		>
-			<div class="sheet">
+			<clay:sheet>
 				<h3 class="sheet-title">
 					<c:choose>
 						<c:when test='<%= Objects.equals(assetListEntryUsagesDisplayContext.getNavigation(), "pages") %>'>
@@ -163,7 +163,7 @@ renderResponse.setTitle(assetListDisplayContext.getAssetListEntryTitle());
 						searchResultCssClass="show-quick-actions-on-hover table table-autofit"
 					/>
 				</liferay-ui:search-container>
-			</div>
+			</clay:sheet>
 		</clay:col>
 	</clay:row>
 </clay:container-fluid>

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entries_abstract.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entries_abstract.jsp
@@ -90,73 +90,75 @@ for (AssetEntry assetEntry : assetEntryResult.getAssetEntries()) {
 			<span class="asset-anchor lfr-asset-anchor" id="<%= assetEntry.getEntryId() %>"></span>
 
 			<c:if test="<%= assetPublisherDisplayContext.isShowAuthor() || (assetPublisherDisplayContext.isShowCreateDate() && (assetEntry.getCreateDate() != null)) || (assetPublisherDisplayContext.isShowPublishDate() && (assetEntry.getPublishDate() != null)) || (assetPublisherDisplayContext.isShowExpirationDate() && (assetEntry.getExpirationDate() != null)) || (assetPublisherDisplayContext.isShowModifiedDate() && (assetEntry.getModifiedDate() != null)) || assetPublisherDisplayContext.isShowViewCount() %>">
-				<div class="autofit-row mb-4 metadata-author">
+				<clay:content-row
+					cssClass="mb-4 metadata-author"
+				>
 					<c:if test="<%= assetPublisherDisplayContext.isShowAuthor() %>">
-						<div class="asset-avatar autofit-col inline-item-before mr-3 pt-1">
+						<clay:content-col
+							cssClass="asset-avatar inline-item-before mr-3 pt-1"
+						>
 							<liferay-ui:user-portrait
 								userId="<%= assetRenderer.getUserId() %>"
 							/>
-						</div>
+						</clay:content-col>
 					</c:if>
 
-					<div class="autofit-col autofit-col-expand">
-						<div class="autofit-row">
-							<div class="autofit-col autofit-col-expand">
-								<c:if test="<%= assetPublisherDisplayContext.isShowAuthor() %>">
-									<div class="text-truncate-inline">
-										<span class="text-truncate user-info"><strong><%= HtmlUtil.escape(AssetRendererUtil.getAssetRendererUserFullName(assetRenderer, request)) %></strong></span>
-									</div>
-								</c:if>
-
-								<%
-								StringBundler sb = new StringBundler(13);
-
-								if (assetPublisherDisplayContext.isShowCreateDate() && (assetEntry.getCreateDate() != null)) {
-									sb.append(LanguageUtil.get(request, "created"));
-									sb.append(StringPool.SPACE);
-									sb.append(dateFormatDate.format(assetEntry.getCreateDate()));
-									sb.append(" - ");
-								}
-
-								if (assetPublisherDisplayContext.isShowPublishDate() && (assetEntry.getPublishDate() != null)) {
-									sb.append(LanguageUtil.get(request, "published"));
-									sb.append(StringPool.SPACE);
-									sb.append(dateFormatDate.format(assetEntry.getPublishDate()));
-									sb.append(" - ");
-								}
-
-								if (assetPublisherDisplayContext.isShowExpirationDate() && (assetEntry.getExpirationDate() != null)) {
-									sb.append(LanguageUtil.get(request, "expired"));
-									sb.append(StringPool.SPACE);
-									sb.append(dateFormatDate.format(assetEntry.getExpirationDate()));
-									sb.append(" - ");
-								}
-
-								if (assetPublisherDisplayContext.isShowModifiedDate() && (assetEntry.getModifiedDate() != null)) {
-									Date modifiedDate = assetEntry.getModifiedDate();
-
-									String modifiedDateDescription = LanguageUtil.getTimeDescription(request, System.currentTimeMillis() - modifiedDate.getTime(), true);
-
-									sb.append(LanguageUtil.format(request, "modified-x-ago", modifiedDateDescription));
-								}
-								else if (sb.index() > 1) {
-									sb.setIndex(sb.index() - 1);
-								}
-								%>
-
-								<div class="asset-user-info text-secondary">
-									<span class="date-info"><%= sb.toString() %></span>
-								</div>
-
-								<c:if test="<%= assetPublisherDisplayContext.isShowViewCount() %>">
-									<div class="asset-view-count-info text-secondary">
-										<span class="view-count-info"><%= assetEntry.getViewCount() %> <liferay-ui:message key='<%= (assetEntry.getViewCount() == 1) ? "view" : "views" %>' /></span>
-									</div>
-								</c:if>
+					<clay:content-col
+						expand="true"
+					>
+						<c:if test="<%= assetPublisherDisplayContext.isShowAuthor() %>">
+							<div class="text-truncate-inline">
+								<span class="text-truncate user-info"><strong><%= HtmlUtil.escape(AssetRendererUtil.getAssetRendererUserFullName(assetRenderer, request)) %></strong></span>
 							</div>
+						</c:if>
+
+						<%
+						StringBundler sb = new StringBundler(13);
+
+						if (assetPublisherDisplayContext.isShowCreateDate() && (assetEntry.getCreateDate() != null)) {
+							sb.append(LanguageUtil.get(request, "created"));
+							sb.append(StringPool.SPACE);
+							sb.append(dateFormatDate.format(assetEntry.getCreateDate()));
+							sb.append(" - ");
+						}
+
+						if (assetPublisherDisplayContext.isShowPublishDate() && (assetEntry.getPublishDate() != null)) {
+							sb.append(LanguageUtil.get(request, "published"));
+							sb.append(StringPool.SPACE);
+							sb.append(dateFormatDate.format(assetEntry.getPublishDate()));
+							sb.append(" - ");
+						}
+
+						if (assetPublisherDisplayContext.isShowExpirationDate() && (assetEntry.getExpirationDate() != null)) {
+							sb.append(LanguageUtil.get(request, "expired"));
+							sb.append(StringPool.SPACE);
+							sb.append(dateFormatDate.format(assetEntry.getExpirationDate()));
+							sb.append(" - ");
+						}
+
+						if (assetPublisherDisplayContext.isShowModifiedDate() && (assetEntry.getModifiedDate() != null)) {
+							Date modifiedDate = assetEntry.getModifiedDate();
+
+							String modifiedDateDescription = LanguageUtil.getTimeDescription(request, System.currentTimeMillis() - modifiedDate.getTime(), true);
+
+							sb.append(LanguageUtil.format(request, "modified-x-ago", modifiedDateDescription));
+						}
+						else if (sb.index() > 1) {
+							sb.setIndex(sb.index() - 1);
+						}
+						%>
+
+						<div class="asset-user-info text-secondary">
+							<span class="date-info"><%= sb.toString() %></span>
 						</div>
-					</div>
-				</div>
+
+						<c:if test="<%= assetPublisherDisplayContext.isShowViewCount() %>">
+							<div class="asset-view-count-info text-secondary">
+								<span class="view-count-info"><%= assetEntry.getViewCount() %> <liferay-ui:message key='<%= (assetEntry.getViewCount() == 1) ? "view" : "views" %>' /></span>
+							</div>
+						</c:if>
+					</clay:content-col>
+				</clay:content-row>
 			</c:if>
 
 			<div class="asset-content mb-3">
@@ -217,18 +219,26 @@ for (AssetEntry assetEntry : assetEntryResult.getAssetEntries()) {
 			<c:if test="<%= (assetPublisherDisplayContext.isEnableRatings() && assetRenderer.isRatable()) || assetPublisherDisplayContext.isEnableFlags() || assetPublisherDisplayContext.isEnablePrint() || Validator.isNotNull(assetPublisherDisplayContext.getSocialBookmarksTypes()) %>">
 				<div class="separator"><!-- --></div>
 
-				<div class="asset-details autofit-float autofit-row autofit-row-center">
+				<clay:content-row
+					cssClass="asset-details"
+					floatElements="true"
+					verticalAlign="center"
+				>
 					<c:if test="<%= assetPublisherDisplayContext.isEnableRatings() && assetRenderer.isRatable() %>">
-						<div class="asset-ratings autofit-col mr-3">
+						<clay:content-col
+							cssClass="asset-ratings mr-3"
+						>
 							<liferay-ratings:ratings
 								className="<%= assetEntry.getClassName() %>"
 								classPK="<%= assetEntry.getClassPK() %>"
 							/>
-						</div>
+						</clay:content-col>
 					</c:if>
 
 					<c:if test="<%= assetPublisherDisplayContext.isEnableFlags() %>">
-						<div class="asset-flag autofit-col mr-3">
+						<clay:content-col
+							cssClass="asset-flag mr-3"
+						>
 
 							<%
 							TrashHandler trashHandler = TrashHandlerRegistryUtil.getTrashHandler(assetRenderer.getClassName());
@@ -245,11 +255,13 @@ for (AssetEntry assetEntry : assetEntryResult.getAssetEntries()) {
 								message='<%= inTrash ? "flags-are-disabled-because-this-entry-is-in-the-recycle-bin" : null %>'
 								reportedUserId="<%= assetRenderer.getUserId() %>"
 							/>
-						</div>
+						</clay:content-col>
 					</c:if>
 
 					<c:if test="<%= assetPublisherDisplayContext.isEnablePrint() %>">
-						<div class="autofit-col component-subtitle mr-3 print-action">
+						<clay:content-col
+							cssClass="component-subtitle mr-3 print-action"
+						>
 
 							<%
 							PortletURL printAssetURL = renderResponse.createRenderURL();
@@ -281,14 +293,14 @@ for (AssetEntry assetEntry : assetEntryResult.getAssetEntries()) {
 									);
 								}
 							</aui:script>
-						</div>
+						</clay:content-col>
 					</c:if>
 
 					<%
 					PortletURL viewFullContentURL = assetPublisherHelper.getBaseAssetViewURL(liferayPortletRequest, liferayPortletResponse, assetRenderer, assetEntry);
 					%>
 
-					<div class="autofit-col">
+					<clay:content-col>
 						<liferay-social-bookmarks:bookmarks
 							className="<%= assetEntry.getClassName() %>"
 							classPK="<%= assetEntry.getClassPK() %>"
@@ -298,14 +310,18 @@ for (AssetEntry assetEntry : assetEntryResult.getAssetEntries()) {
 							types="<%= assetPublisherDisplayContext.getSocialBookmarksTypes() %>"
 							urlImpl="<%= viewFullContentURL %>"
 						/>
-					</div>
-				</div>
+					</clay:content-col>
+				</clay:content-row>
 			</c:if>
 
 			<c:if test="<%= (assetPublisherDisplayContext.isShowAvailableLocales() && assetRenderer.isLocalizable()) || (assetPublisherDisplayContext.isEnableConversions() && assetRenderer.isConvertible()) %>">
 				<div class="separator"><!-- --></div>
 
-				<div class="asset-details autofit-float autofit-row autofit-row-center">
+				<clay:content-row
+					cssClass="asset-details"
+					floatElements="true"
+					verticalAlign="center"
+				>
 					<c:if test="<%= assetPublisherDisplayContext.isShowAvailableLocales() && assetRenderer.isLocalizable() %>">
 
 						<%
@@ -319,13 +335,15 @@ for (AssetEntry assetEntry : assetEntryResult.getAssetEntries()) {
 						%>
 
 						<c:if test="<%= availableLanguageIds.length > 1 %>">
-							<div class="autofit-col locale-actions mr-3">
+							<clay:content-col
+								cssClass="locale-actions mr-3"
+							>
 								<liferay-ui:language
 									formAction="<%= currentURL %>"
 									languageId="<%= languageId %>"
 									languageIds="<%= availableLanguageIds %>"
 								/>
-							</div>
+							</clay:content-col>
 						</c:if>
 					</c:if>
 
@@ -346,16 +364,18 @@ for (AssetEntry assetEntry : assetEntryResult.getAssetEntries()) {
 							).build();
 						%>
 
-							<div class="autofit-col export-action">
+							<clay:content-col
+								cssClass="export-action"
+							>
 								<aui:a cssClass="btn btn-outline-borderless btn-outline-secondary btn-sm" data="<%= data %>" href="<%= exportAssetURL.toString() %>" label='<%= LanguageUtil.format(request, "x-convert-x-to-x", new Object[] {"hide-accessible", title, StringUtil.toUpperCase(HtmlUtil.escape(extension))}, false) %>' />
-							</div>
+							</clay:content-col>
 
 						<%
 						}
 						%>
 
 					</c:if>
-				</div>
+				</clay:content-row>
 			</c:if>
 
 			<c:if test="<%= assetPublisherDisplayContext.isEnableComments() && assetRenderer.isCommentable() %>">

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entries_table.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entries_table.jsp
@@ -30,16 +30,16 @@ if (stageableGroup.isLayout()) {
 }
 %>
 
-<div class="sheet">
+<clay:sheet>
 	<c:if test="<%= Validator.isNotNull(assetEntryResult.getTitle()) %>">
-		<div class="sheet-header">
+		<clay:sheet-header>
 			<h4 class="sheet-title">
 				<%= assetEntryResult.getTitle() %>
 			</h4>
-		</div>
+		</clay:sheet-header>
 	</c:if>
 
-	<div class="sheet-section">
+	<clay:sheet-section>
 		<div class="table-responsive">
 			<table class="table table-autofit">
 				<thead>
@@ -216,8 +216,8 @@ if (stageableGroup.isLayout()) {
 				</tbody>
 			</table>
 		</div>
-	</div>
-</div>
+	</clay:sheet-section>
+</clay:sheet>
 
 <%!
 private static Log _log = LogFactoryUtil.getLog("com_liferay_asset_publisher_web.view_asset_entries_table_jsp");

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entries_title_list.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entries_title_list.jsp
@@ -71,16 +71,18 @@ AssetEntryResult assetEntryResult = (AssetEntryResult)request.getAttribute("view
 
 		<li class="list-group-item list-group-item-flex <%= ((previewClassNameId == assetEntry.getClassNameId()) && (previewClassPK == assetEntry.getClassPK())) ? "active" : StringPool.BLANK %>" <%= AUIUtil.buildData(fragmentsEditorData) %>>
 			<c:if test="<%= assetPublisherDisplayContext.isShowAuthor() %>">
-				<div class="autofit-col">
+				<clay:content-col>
 					<span class="inline-item">
 						<liferay-ui:user-portrait
 							userId="<%= assetEntry.getUserId() %>"
 						/>
 					</span>
-				</div>
+				</clay:content-col>
 			</c:if>
 
-			<div class="autofit-col autofit-col-expand">
+			<clay:content-col
+				expand="true"
+			>
 				<h4 class="list-group-title text-truncate">
 					<span class="asset-anchor lfr-asset-anchor" id="<%= assetEntry.getEntryId() %>"></span>
 
@@ -126,11 +128,11 @@ AssetEntryResult assetEntryResult = (AssetEntryResult)request.getAttribute("view
 						</c:if>
 					</div>
 				</c:if>
-			</div>
+			</clay:content-col>
 
-			<div class="autofit-col">
+			<clay:content-col>
 				<liferay-util:include page="/asset_actions.jsp" servletContext="<%= application %>" />
-			</div>
+			</clay:content-col>
 		</li>
 
 	<%

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entry_full_content.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entry_full_content.jsp
@@ -105,74 +105,76 @@ Map<String, Object> fragmentsEditorData = HashMapBuilder.<String, Object>put(
 	<span class="asset-anchor lfr-asset-anchor" id="<%= assetEntry.getEntryId() %>"></span>
 
 	<c:if test="<%= assetPublisherDisplayContext.isShowAuthor() || (assetPublisherDisplayContext.isShowCreateDate() && (assetEntry.getCreateDate() != null)) || (assetPublisherDisplayContext.isShowPublishDate() && (assetEntry.getPublishDate() != null)) || (assetPublisherDisplayContext.isShowExpirationDate() && (assetEntry.getExpirationDate() != null)) || (assetPublisherDisplayContext.isShowModifiedDate() && (assetEntry.getModifiedDate() != null)) || assetPublisherDisplayContext.isShowViewCount() %>">
-		<div class="autofit-row mb-4 metadata-author">
+		<clay:content-row
+			cssClass="mb-4 metadata-author"
+		>
 			<c:if test="<%= assetPublisherDisplayContext.isShowAuthor() %>">
-				<div class="asset-avatar autofit-col inline-item-before mr-3 pt-1">
+				<clay:content-col
+					cssClass="asset-avatar inline-item-before mr-3 pt-1"
+				>
 					<liferay-ui:user-portrait
 						size="lg"
 						userId="<%= assetRenderer.getUserId() %>"
 					/>
-				</div>
+				</clay:content-col>
 			</c:if>
 
-			<div class="autofit-col autofit-col-expand">
-				<div class="autofit-row">
-					<div class="autofit-col autofit-col-expand">
-						<c:if test="<%= assetPublisherDisplayContext.isShowAuthor() %>">
-							<div class="text-truncate-inline">
-								<span class="text-truncate user-info"><strong><%= HtmlUtil.escape(AssetRendererUtil.getAssetRendererUserFullName(assetRenderer, request)) %></strong></span>
-							</div>
-						</c:if>
-
-						<%
-						StringBundler sb = new StringBundler(13);
-
-						if (assetPublisherDisplayContext.isShowCreateDate() && (assetEntry.getCreateDate() != null)) {
-							sb.append(LanguageUtil.get(request, "created"));
-							sb.append(StringPool.SPACE);
-							sb.append(dateFormatDate.format(assetEntry.getCreateDate()));
-							sb.append(" - ");
-						}
-
-						if (assetPublisherDisplayContext.isShowPublishDate() && (assetEntry.getPublishDate() != null)) {
-							sb.append(LanguageUtil.get(request, "published"));
-							sb.append(StringPool.SPACE);
-							sb.append(dateFormatDate.format(assetEntry.getPublishDate()));
-							sb.append(" - ");
-						}
-
-						if (assetPublisherDisplayContext.isShowExpirationDate() && (assetEntry.getExpirationDate() != null)) {
-							sb.append(LanguageUtil.get(request, "expired"));
-							sb.append(StringPool.SPACE);
-							sb.append(dateFormatDate.format(assetEntry.getExpirationDate()));
-							sb.append(" - ");
-						}
-
-						if (assetPublisherDisplayContext.isShowModifiedDate() && (assetEntry.getModifiedDate() != null)) {
-							Date modifiedDate = assetEntry.getModifiedDate();
-
-							String modifiedDateDescription = LanguageUtil.getTimeDescription(request, System.currentTimeMillis() - modifiedDate.getTime(), true);
-
-							sb.append(LanguageUtil.format(request, "modified-x-ago", modifiedDateDescription));
-						}
-						else if (sb.index() > 1) {
-							sb.setIndex(sb.index() - 1);
-						}
-						%>
-
-						<div class="asset-user-info text-secondary">
-							<span class="date-info"><%= sb.toString() %></span>
-						</div>
-
-						<c:if test="<%= assetPublisherDisplayContext.isShowViewCount() %>">
-							<div class="asset-view-count-info text-secondary">
-								<span class="view-count-info"><%= assetEntry.getViewCount() %> <liferay-ui:message key='<%= (assetEntry.getViewCount() == 1) ? "view" : "views" %>' /></span>
-							</div>
-						</c:if>
+			<clay:content-col
+				expand="true"
+			>
+				<c:if test="<%= assetPublisherDisplayContext.isShowAuthor() %>">
+					<div class="text-truncate-inline">
+						<span class="text-truncate user-info"><strong><%= HtmlUtil.escape(AssetRendererUtil.getAssetRendererUserFullName(assetRenderer, request)) %></strong></span>
 					</div>
+				</c:if>
+
+				<%
+				StringBundler sb = new StringBundler(13);
+
+				if (assetPublisherDisplayContext.isShowCreateDate() && (assetEntry.getCreateDate() != null)) {
+					sb.append(LanguageUtil.get(request, "created"));
+					sb.append(StringPool.SPACE);
+					sb.append(dateFormatDate.format(assetEntry.getCreateDate()));
+					sb.append(" - ");
+				}
+
+				if (assetPublisherDisplayContext.isShowPublishDate() && (assetEntry.getPublishDate() != null)) {
+					sb.append(LanguageUtil.get(request, "published"));
+					sb.append(StringPool.SPACE);
+					sb.append(dateFormatDate.format(assetEntry.getPublishDate()));
+					sb.append(" - ");
+				}
+
+				if (assetPublisherDisplayContext.isShowExpirationDate() && (assetEntry.getExpirationDate() != null)) {
+					sb.append(LanguageUtil.get(request, "expired"));
+					sb.append(StringPool.SPACE);
+					sb.append(dateFormatDate.format(assetEntry.getExpirationDate()));
+					sb.append(" - ");
+				}
+
+				if (assetPublisherDisplayContext.isShowModifiedDate() && (assetEntry.getModifiedDate() != null)) {
+					Date modifiedDate = assetEntry.getModifiedDate();
+
+					String modifiedDateDescription = LanguageUtil.getTimeDescription(request, System.currentTimeMillis() - modifiedDate.getTime(), true);
+
+					sb.append(LanguageUtil.format(request, "modified-x-ago", modifiedDateDescription));
+				}
+				else if (sb.index() > 1) {
+					sb.setIndex(sb.index() - 1);
+				}
+				%>
+
+				<div class="asset-user-info text-secondary">
+					<span class="date-info"><%= sb.toString() %></span>
 				</div>
-			</div>
-		</div>
+
+				<c:if test="<%= assetPublisherDisplayContext.isShowViewCount() %>">
+					<div class="asset-view-count-info text-secondary">
+						<span class="view-count-info"><%= assetEntry.getViewCount() %> <liferay-ui:message key='<%= (assetEntry.getViewCount() == 1) ? "view" : "views" %>' /></span>
+					</div>
+				</c:if>
+			</clay:content-col>
+		</clay:content-row>
 	</c:if>
 
 	<div class="asset-content mb-3">
@@ -240,20 +242,28 @@ Map<String, Object> fragmentsEditorData = HashMapBuilder.<String, Object>put(
 	<c:if test="<%= showContextLink || showRatings || assetPublisherDisplayContext.isEnableFlags() || assetPublisherDisplayContext.isEnablePrint() || Validator.isNotNull(assetPublisherDisplayContext.getSocialBookmarksTypes()) %>">
 		<div class="separator"><!-- --></div>
 
-		<div class="asset-details autofit-float autofit-row autofit-row-center">
+		<clay:content-row
+			cssClass="asset-details"
+			floatElements="true"
+			verticalAlign="center"
+		>
 			<c:if test="<%= showContextLink %>">
-				<div class="asset-more autofit-col mr-3">
+				<clay:content-col
+					cssClass="asset-more mr-3"
+				>
 					<a href="<%= viewInContextURL %>"><liferay-ui:message key="<%= assetRenderer.getViewInContextMessage() %>" /> &raquo;</a>
-				</div>
+				</clay:content-col>
 			</c:if>
 
 			<c:if test="<%= showRatings %>">
-				<div class="asset-ratings autofit-col mr-3">
+				<clay:content-col
+					cssClass="asset-ratings mr-3"
+				>
 					<liferay-ratings:ratings
 						className="<%= assetEntry.getClassName() %>"
 						classPK="<%= assetEntry.getClassPK() %>"
 					/>
-				</div>
+				</clay:content-col>
 			</c:if>
 
 			<c:if test="<%= assetPublisherDisplayContext.isEnableFlags() %>">
@@ -264,7 +274,9 @@ Map<String, Object> fragmentsEditorData = HashMapBuilder.<String, Object>put(
 				boolean inTrash = trashHandler.isInTrash(assetEntry.getClassPK());
 				%>
 
-				<div class="asset-flag autofit-col mr-3">
+				<clay:content-col
+					cssClass="asset-flag mr-3"
+				>
 					<liferay-flags:flags
 						className="<%= assetEntry.getClassName() %>"
 						classPK="<%= assetEntry.getClassPK() %>"
@@ -274,11 +286,13 @@ Map<String, Object> fragmentsEditorData = HashMapBuilder.<String, Object>put(
 						message='<%= inTrash ? "flags-are-disabled-because-this-entry-is-in-the-recycle-bin" : null %>'
 						reportedUserId="<%= assetRenderer.getUserId() %>"
 					/>
-				</div>
+				</clay:content-col>
 			</c:if>
 
 			<c:if test="<%= assetPublisherDisplayContext.isEnablePrint() %>">
-				<div class="autofit-col component-subtitle mr-3 print-action">
+				<clay:content-col
+					cssClass="component-subtitle mr-3 print-action"
+				>
 					<c:choose>
 						<c:when test="<%= print %>">
 							<liferay-ui:icon
@@ -329,11 +343,11 @@ Map<String, Object> fragmentsEditorData = HashMapBuilder.<String, Object>put(
 							</aui:script>
 						</c:otherwise>
 					</c:choose>
-				</div>
+				</clay:content-col>
 			</c:if>
 
 			<c:if test="<%= Validator.isNotNull(assetPublisherDisplayContext.getSocialBookmarksTypes()) %>">
-				<div class="autofit-col">
+				<clay:content-col>
 					<liferay-social-bookmarks:bookmarks
 						className="<%= assetEntry.getClassName() %>"
 						classPK="<%= assetEntry.getClassPK() %>"
@@ -343,9 +357,9 @@ Map<String, Object> fragmentsEditorData = HashMapBuilder.<String, Object>put(
 						types="<%= assetPublisherDisplayContext.getSocialBookmarksTypes() %>"
 						urlImpl="<%= viewFullContentURL %>"
 					/>
-				</div>
+				</clay:content-col>
 			</c:if>
-		</div>
+		</clay:content-row>
 	</c:if>
 
 	<%
@@ -356,7 +370,11 @@ Map<String, Object> fragmentsEditorData = HashMapBuilder.<String, Object>put(
 	<c:if test="<%= showConversions || showLocalization %>">
 		<div class="separator"><!-- --></div>
 
-		<div class="asset-details autofit-float autofit-row autofit-row-center">
+		<clay:content-row
+			cssClass="asset-details"
+			floatElements="true"
+			verticalAlign="center"
+		>
 			<c:if test="<%= showLocalization %>">
 
 				<%
@@ -397,16 +415,18 @@ Map<String, Object> fragmentsEditorData = HashMapBuilder.<String, Object>put(
 					).build();
 				%>
 
-					<div class="autofit-col component-subtitle export-action">
+					<clay:content-col
+						cssClass="component-subtitle export-action"
+					>
 						<aui:a cssClass="btn btn-outline-borderless btn-outline-secondary btn-sm" data="<%= data %>" href="<%= exportAssetURL.toString() %>" label='<%= LanguageUtil.format(request, "x-convert-x-to-x", new Object[] {"hide-accessible", title, StringUtil.toUpperCase(HtmlUtil.escape(extension))}, false) %>' />
-					</div>
+					</clay:content-col>
 
 				<%
 				}
 				%>
 
 			</c:if>
-		</div>
+		</clay:content-row>
 	</c:if>
 
 	<c:if test="<%= assetPublisherDisplayContext.isEnableComments() && assetRenderer.isCommentable() %>">

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_addon_entry_selector/init.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_addon_entry_selector/init.jsp
@@ -15,6 +15,7 @@
 --%>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_addon_entry_selector/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_addon_entry_selector/page.jsp
@@ -29,21 +29,26 @@
 				<div class="card card-horizontal card-type-directory">
 					<div class="card-body">
 						<div class="card-row">
-							<div class="autofit-col autofit-col-expand autofit-col-gutters">
-								<section class="autofit-section">
+							<clay:content-col
+								expand="true"
+								gutters="true"
+							>
+								<clay:content-section
+									containerElement="section"
+								>
 									<h3 class="card-title" title="{label}">
 										<span class="text-truncate-inline">
 											<span class="text-truncate"><%= assetAddonEntry.getLabel(locale) %></span>
 										</span>
 									</h3>
-								</section>
-							</div>
+								</clay:content-section>
+							</clay:content-col>
 
-							<div class="autofit-col">
+							<clay:content-col>
 								<a class="remove-button" href="javascript:;">
 									<aui:icon image="times-circle" markupView="lexicon" />
 								</a>
-							</div>
+							</clay:content-col>
 						</div>
 					</div>
 				</div>

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_entry_usages/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_entry_usages/page.jsp
@@ -99,7 +99,7 @@ AssetEntryUsagesDisplayContext assetEntryUsagesDisplayContext = new AssetEntryUs
 		<clay:col
 			lg="9"
 		>
-			<div class="sheet">
+			<clay:sheet>
 				<h3 class="sheet-title">
 					<c:choose>
 						<c:when test='<%= Objects.equals(assetEntryUsagesDisplayContext.getNavigation(), "pages") %>'>
@@ -178,7 +178,7 @@ AssetEntryUsagesDisplayContext assetEntryUsagesDisplayContext = new AssetEntryUs
 						searchResultCssClass="show-quick-actions-on-hover table table-autofit"
 					/>
 				</liferay-ui:search-container>
-			</div>
+			</clay:sheet>
 		</clay:col>
 	</clay:row>
 </clay:container-fluid>

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_links/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_links/page.jsp
@@ -34,16 +34,20 @@ List<Tuple> assetLinkEntries = (List<Tuple>)request.getAttribute("liferay-asset:
 	%>
 
 		<li class="list-group-item list-group-item-flex">
-			<div class="autofit-col">
+			<clay:content-col>
 				<clay:sticker
 					displayType="secondary"
 					icon="<%= assetRenderer.getIconCssClass() %>"
 					inline="true"
 				/>
-			</div>
+			</clay:content-col>
 
-			<div class="autofit-col autofit-col-expand">
-				<section class="autofit-section">
+			<clay:content-col
+				expand="true"
+			>
+				<clay:content-section
+					containerElement="section"
+				>
 					<div class="list-group-title text-truncate-inline">
 						<c:choose>
 							<c:when test="<%= assetRenderer.getStatus() == WorkflowConstants.STATUS_SCHEDULED %>">
@@ -61,8 +65,8 @@ List<Tuple> assetLinkEntries = (List<Tuple>)request.getAttribute("liferay-asset:
 							</c:otherwise>
 						</c:choose>
 					</div>
-				</section>
-			</div>
+				</clay:content-section>
+			</clay:content-col>
 		</li>
 
 	<%

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/edit_configuration.jsp
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/edit_configuration.jsp
@@ -105,7 +105,7 @@ renderResponse.setTitle(categoryDisplayName);
 		<clay:col
 			md="9"
 		>
-			<div class="sheet sheet-lg">
+			<clay:sheet>
 				<aui:form action="<%= bindConfigurationActionURL %>" method="post" name="fm">
 					<aui:input name="redirect" type="hidden" value="<%= bindRedirectURL %>" />
 					<aui:input name="factoryPid" type="hidden" value="<%= configurationModel.getFactoryPid() %>" />
@@ -243,7 +243,7 @@ renderResponse.setTitle(categoryDisplayName);
 						<aui:button href="<%= redirect %>" name="cancel" type="cancel" />
 					</aui:button-row>
 				</aui:form>
-			</div>
+			</clay:sheet>
 		</clay:col>
 	</clay:row>
 </clay:container-fluid>

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/view_factory_instances.jsp
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/view_factory_instances.jsp
@@ -74,14 +74,14 @@ renderResponse.setTitle(categoryDisplayName);
 		<clay:col
 			md="9"
 		>
-			<div class="sheet sheet-lg">
-				<div class="autofit-row">
-					<div class="autofit-col">
+			<clay:sheet>
+				<clay:content-row>
+					<clay:content-col>
 						<h2><%= factoryConfigurationModelName %></h2>
-					</div>
+					</clay:content-col>
 
 					<c:if test="<%= configurationModelIterator.getTotal() > 0 %>">
-						<div class="autofit-col">
+						<clay:content-col>
 							<liferay-ui:icon-menu
 								cssClass="float-right"
 								direction="right"
@@ -99,17 +99,26 @@ renderResponse.setTitle(categoryDisplayName);
 									url="<%= exportEntriesURL %>"
 								/>
 							</liferay-ui:icon-menu>
-						</div>
+						</clay:content-col>
 					</c:if>
-				</div>
+				</clay:content-row>
 
-				<h3 class="autofit-row sheet-subtitle">
-					<span class="autofit-col autofit-col-expand">
+				<clay:content-row
+					containerElement="h3"
+					cssClass="sheet-subtitle"
+				>
+					<clay:content-col
+						containerElement="span"
+						expand="true"
+					>
 						<span class="heading-text">
 							<liferay-ui:message key="configuration-entries" />
 						</span>
-					</span>
-					<span class="autofit-col">
+					</clay:content-col>
+
+					<clay:content-col
+						containerElement="span"
+					>
 						<span class="heading-end">
 							<portlet:renderURL var="createFactoryConfigURL">
 								<portlet:param name="mvcRenderCommandName" value="/edit_configuration" />
@@ -119,8 +128,8 @@ renderResponse.setTitle(categoryDisplayName);
 
 							<a class="btn btn-secondary btn-sm" href="<%= createFactoryConfigURL %>"><liferay-ui:message key="add" /></a>
 						</span>
-					</span>
-				</h3>
+					</clay:content-col>
+				</clay:content-row>
 
 				<%
 				PortletURL iteratorURL = renderResponse.createRenderURL();
@@ -223,7 +232,7 @@ renderResponse.setTitle(categoryDisplayName);
 						searchResultCssClass="show-quick-actions-on-hover table table-autofit"
 					/>
 				</liferay-ui:search-container>
-			</div>
+			</clay:sheet>
 		</clay:col>
 	</clay:row>
 </clay:container-fluid>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/template_selector/page.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/template_selector/page.jsp
@@ -26,7 +26,7 @@ Group ddmTemplateGroup = GroupLocalServiceUtil.getGroup(ddmTemplateGroupId);
 %>
 
 <clay:content-row
-	verticaAlign="center"
+	verticalAlign="center"
 >
 	<clay:content-col
 		cssClass="inline-item-before"

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view.jsp
@@ -41,14 +41,19 @@ List<FragmentCollectionContributor> fragmentCollectionContributors = fragmentDis
 
 						<c:choose>
 							<c:when test="<%= ListUtil.isNotEmpty(fragmentCollections) || ListUtil.isNotEmpty(fragmentCollectionContributors) || MapUtil.isNotEmpty(inheritedFragmentCollections) %>">
-								<div class="autofit-row autofit-row-center mb-4">
-									<div class="autofit-col autofit-col-expand">
+								<clay:content-row
+									cssClass="mb-4"
+									verticalAlign="center"
+								>
+									<clay:content-col
+										expand="true"
+									>
 										<strong class="text-uppercase">
 											<liferay-ui:message key="collections" />
 										</strong>
-									</div>
+									</clay:content-col>
 
-									<div class="autofit-col autofit-col-end">
+									<clay:content-col>
 										<ul class="navbar-nav">
 											<li>
 												<c:if test="<%= FragmentPermission.contains(permissionChecker, scopeGroupId, FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES) %>">
@@ -67,8 +72,8 @@ List<FragmentCollectionContributor> fragmentCollectionContributors = fragmentDis
 												/>
 											</li>
 										</ul>
-									</div>
-								</div>
+									</clay:content-col>
+								</clay:content-row>
 
 								<ul class="mb-2 nav nav-stacked">
 									<c:if test="<%= ListUtil.isNotEmpty(fragmentCollectionContributors) || ListUtil.isNotEmpty(systemFragmentCollections) %>">
@@ -234,22 +239,26 @@ List<FragmentCollectionContributor> fragmentCollectionContributors = fragmentDis
 			lg="9"
 		>
 			<c:if test="<%= (fragmentDisplayContext.getFragmentCollection() != null) || (fragmentDisplayContext.getFragmentCollectionContributor() != null) %>">
-				<div class="sheet">
+				<clay:sheet>
 					<h2 class="sheet-title">
-						<div class="autofit-row autofit-row-center">
-							<div class="autofit-col">
+						<clay:content-row
+							verticalAlign="center"
+						>
+							<clay:content-col>
 								<%= fragmentDisplayContext.getFragmentCollectionName() %>
-							</div>
+							</clay:content-col>
 
 							<c:if test="<%= fragmentDisplayContext.showFragmentCollectionActions() %>">
-								<div class="autofit-col autofit-col-end inline-item-after">
+								<clay:content-col
+									cssClass="inline-item-after"
+								>
 									<liferay-util:include page="/fragment_collection_action.jsp" servletContext="<%= application %>" />
-								</div>
+								</clay:content-col>
 							</c:if>
-						</div>
+						</clay:content-row>
 					</h2>
 
-					<div class="sheet-section">
+					<clay:sheet-section>
 						<clay:navigation-bar
 							navigationItems="<%= fragmentDisplayContext.getNavigationItems() %>"
 						/>
@@ -269,8 +278,8 @@ List<FragmentCollectionContributor> fragmentCollectionContributors = fragmentDis
 								</c:choose>
 							</c:otherwise>
 						</c:choose>
-					</div>
-				</div>
+					</clay:sheet-section>
+				</clay:sheet>
 			</c:if>
 		</clay:col>
 	</clay:row>

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view_fragment_entry_usages.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view_fragment_entry_usages.jsp
@@ -101,10 +101,12 @@ FragmentEntryUsageManagementToolbarDisplayContext fragmentEntryUsageManagementTo
 		<clay:col
 			lg="9"
 		>
-			<div class="sheet">
+			<clay:sheet>
 				<h2 class="sheet-title">
-					<div class="autofit-row autofit-row-center">
-						<div class="autofit-col">
+					<clay:content-row
+						verticalAlign="center"
+					>
+						<clay:content-col>
 							<c:choose>
 								<c:when test='<%= Objects.equals(fragmentEntryLinkDisplayContext.getNavigation(), "pages") %>'>
 									<liferay-ui:message arguments="<%= fragmentEntryLinkDisplayContext.getPagesUsageCount() %>" key="pages-x" />
@@ -119,8 +121,8 @@ FragmentEntryUsageManagementToolbarDisplayContext fragmentEntryUsageManagementTo
 									<liferay-ui:message arguments="<%= fragmentEntryLinkDisplayContext.getAllUsageCount() %>" key="all-x" />
 								</c:otherwise>
 							</c:choose>
-						</div>
-					</div>
+						</clay:content-col>
+					</clay:content-row>
 				</h2>
 
 				<clay:management-toolbar
@@ -172,7 +174,7 @@ FragmentEntryUsageManagementToolbarDisplayContext fragmentEntryUsageManagementTo
 						/>
 					</liferay-ui:search-container>
 				</aui:form>
-			</div>
+			</clay:sheet>
 		</clay:col>
 	</clay:row>
 </clay:container-fluid>

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view_group_fragment_entry_usages.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view_group_fragment_entry_usages.jsp
@@ -32,7 +32,7 @@ GroupFragmentEntryUsageManagementToolbarDisplayContext groupFragmentEntryUsageMa
 <clay:container-fluid
 	cssClass="container-form-lg"
 >
-	<div class="sheet">
+	<clay:sheet>
 		<clay:row>
 			<clay:col
 				lg="12"
@@ -77,7 +77,7 @@ GroupFragmentEntryUsageManagementToolbarDisplayContext groupFragmentEntryUsageMa
 				</aui:form>
 			</clay:col>
 		</clay:row>
-	</div>
+	</clay:sheet>
 </clay:container-fluid>
 
 <liferay-frontend:component

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_layout_page_template_collections.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_layout_page_template_collections.jsp
@@ -47,7 +47,7 @@ List<LayoutPageTemplateCollection> layoutPageTemplateCollections = layoutPageTem
 						<c:choose>
 							<c:when test="<%= ListUtil.isNotEmpty(layoutPageTemplateCollections) %>">
 								<clay:content-row
-									verticaAlign="center"
+									verticalAlign="center"
 								>
 									<clay:content-col
 										expand="true"
@@ -58,7 +58,7 @@ List<LayoutPageTemplateCollection> layoutPageTemplateCollections = layoutPageTem
 									</clay:content-col>
 
 									<clay:content-col
-										verticaAlign="end"
+										verticalAlign="end"
 									>
 										<ul class="navbar-nav">
 											<c:if test="<%= layoutPageTemplateDisplayContext.isShowAddButton(LayoutPageTemplateActionKeys.ADD_LAYOUT_PAGE_TEMPLATE_COLLECTION) %>">
@@ -138,7 +138,7 @@ List<LayoutPageTemplateCollection> layoutPageTemplateCollections = layoutPageTem
 				<clay:sheet>
 					<h2 class="sheet-title">
 						<clay:content-row
-							verticaAlign="center"
+							verticalAlign="center"
 						>
 							<clay:content-col
 								expand="true"
@@ -150,7 +150,7 @@ List<LayoutPageTemplateCollection> layoutPageTemplateCollections = layoutPageTem
 
 							<clay:content-col
 								cssClass="inline-item-after"
-								verticaAlign="end"
+								verticalAlign="end"
 							>
 								<liferay-util:include page="/layout_page_template_collection_action.jsp" servletContext="<%= application %>" />
 							</clay:content-col>

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/pages_tree.jsp
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/pages_tree.jsp
@@ -40,13 +40,22 @@ LayoutsTreeDisplayContext layoutsTreeDisplayContext = new LayoutsTreeDisplayCont
 	<liferay-util:buffer
 		var="linkTemplate"
 	>
-		<span class="autofit-row">
-			<span className="autofit-col">
+		<clay:content-row
+			containerElement="span"
+		>
+			<clay:content-col
+				containerElement="span"
+			>
 				<a class="{cssClass}" data-regular-url="{regularURL}" data-url="{url}" data-uuid="{uuid}" href="{url}" id="{id}" title="{title}">
 					{label}
 				</a>
-			</span>
-			<span class="autofit-col autofit-col-expand pages-tree-dropdown">
+			</clay:content-col>
+
+			<clay:content-col
+				containerElement="span"
+				cssClass="pages-tree-dropdown"
+				expand="true"
+			>
 				<span class="d-sm-block dropdown text-right">
 					<button class="btn btn-unstyled dropdown-toggle ml-1 taglib-icon" data-toggle="liferay-dropdown">
 						<aui:icon image="ellipsis-v" markupView="lexicon" />
@@ -59,29 +68,49 @@ LayoutsTreeDisplayContext layoutsTreeDisplayContext = new LayoutsTreeDisplayCont
 					<ul class="dropdown-menu dropdown-menu-left" role="menu">
 						<c:if test="<%= (stagingGroup == null) || Objects.equals(scopeGroupId, stagingGroupId) %>">
 							<li>
-								<a class="autofit-row dropdown-item layout-action" href="<%= layoutsTreeDisplayContext.getAddChildURLTemplate() %>">
-									<span class="autofit-col autofit-col-expand">
-										<span class="autofit-section text-left">
+								<clay:content-row
+									containerElement="a"
+									cssClass="dropdown-item layout-action"
+									href="<%= layoutsTreeDisplayContext.getAddChildURLTemplate() %>"
+								>
+									<clay:content-col
+										containerElement="span"
+										expand="true"
+									>
+										<clay:content-section
+											containerElement="span"
+											cssClass="text-left"
+										>
 											<liferay-ui:message key="add-child-page" />
-										</span>
-									</span>
-								</a>
+										</clay:content-section>
+									</clay:content-col>
+								</clay:content-row>
 							</li>
 						</c:if>
 
 						<li>
-							<a class="autofit-row dropdown-item layout-action" href="<%= layoutsTreeDisplayContext.getConfigureLayoutURLTemplate() %>">
-								<span class="autofit-col autofit-col-expand">
-									<span class="autofit-section text-left">
+							<clay:content-row
+								containerElement="a"
+								cssClass="dropdown-item layout-action"
+								href="<%= layoutsTreeDisplayContext.getConfigureLayoutURLTemplate() %>"
+							>
+								<clay:content-col
+									containerElement="span"
+									expand="true"
+								>
+									<clay:content-section
+										containerElement="span"
+										cssClass="text-left"
+									>
 										<liferay-ui:message key="configure" />
-									</span>
-								</span>
-							</a>
+									</clay:content-section>
+								</clay:content-col>
+							</clay:content-row>
 						</li>
 					</ul>
 				</span>
-			</span>
-		</span>
+			</clay:content-col>
+		</clay:content-row>
 	</liferay-util:buffer>
 
 	<%

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/view.jsp
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/view.jsp
@@ -25,8 +25,10 @@ String pagesTreeState = SessionClicks.get(request, "com.liferay.product.navigati
 	<div class="sidebar-header">
 		<h1 class="sr-only"><liferay-ui:message key="product-admin-menu" /></h1>
 
-		<div class="autofit-row">
-			<div class="autofit-col autofit-col-expand">
+		<clay:content-row>
+			<clay:content-col
+				expand="true"
+			>
 				<a href="<%= PortalUtil.addPreservedParameters(themeDisplay, themeDisplay.getURLPortal(), false, true) %>">
 					<span class="company-details text-truncate">
 						<img alt="" class="company-logo" src='<%= themeDisplay.getPathImage() + "/company_logo?img_id=" + company.getLogoId() + "&t=" + WebServerServletTokenUtil.getToken(company.getLogoId()) %>' />
@@ -34,12 +36,12 @@ String pagesTreeState = SessionClicks.get(request, "com.liferay.product.navigati
 						<span class="company-name"><%= HtmlUtil.escape(company.getName()) %></span>
 					</span>
 				</a>
-			</div>
+			</clay:content-col>
 
-			<div class="autofit-col">
+			<clay:content-col>
 				<aui:icon cssClass="d-inline-block d-md-none icon-monospaced sidenav-close" image="times" markupView="lexicon" url="javascript:;" />
-			</div>
-		</div>
+			</clay:content-col>
+		</clay:content-row>
 	</div>
 
 	<div class="sidebar-body">

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/content/content.jsp
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/content/content.jsp
@@ -54,8 +54,12 @@ ContentPanelCategoryDisplayContext contentPanelCategoryDisplayContext = new Cont
 					Group curScopeGroup = themeDisplay.getScopeGroup();
 					%>
 
-					<div class="autofit-row autofit-row-center">
-						<div class="autofit-col autofit-col-expand">
+					<clay:content-row
+						verticalAlign="center"
+					>
+						<clay:content-col
+							expand="true"
+						>
 							<span class="scope-name">
 								<c:choose>
 									<c:when test="<%= curScopeGroup.isLayout() %>">
@@ -66,16 +70,16 @@ ContentPanelCategoryDisplayContext contentPanelCategoryDisplayContext = new Cont
 									</c:otherwise>
 								</c:choose>
 							</span>
-						</div>
+						</clay:content-col>
 
-						<div class="autofit-col autofit-col-end">
+						<clay:content-col>
 							<clay:dropdown-menu
 								dropdownItems="<%= contentPanelCategoryDisplayContext.getScopesDropdownItemList() %>"
 								icon="cog"
 								triggerCssClasses="dropdown-toggle icon-monospaced text-light"
 							/>
-						</div>
-					</div>
+						</clay:content-col>
+					</clay:content-row>
 
 					<liferay-application-list:panel-category-body
 						panelCategory="<%= panelCategory %>"

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_header.jsp
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_header.jsp
@@ -138,8 +138,10 @@ portletURL.setWindowState(LiferayWindowState.EXCLUSIVE);
 <c:choose>
 	<c:when test="<%= group != null %>">
 		<a aria-controls="<portlet:namespace /><%= AUIUtil.normalizeId(panelCategory.getKey()) %>Collapse" aria-expanded="<%= siteAdministrationPanelCategoryDisplayContext.isCollapsedPanel() %>" class="panel-toggler <%= (group != null) ? "collapse-icon collapse-icon-middle " : StringPool.BLANK %> <%= siteAdministrationPanelCategoryDisplayContext.isCollapsedPanel() ? StringPool.BLANK : "collapsed" %> site-administration-toggler" data-parent="#<portlet:namespace />Accordion" data-qa-id="productMenuSiteAdministrationPanelCategory" data-toggle="liferay-collapse" href="#<portlet:namespace /><%= AUIUtil.normalizeId(panelCategory.getKey()) %>Collapse" id="<portlet:namespace /><%= AUIUtil.normalizeId(panelCategory.getKey()) %>Toggler" <%= (group != null) ? "role=\"button\"" : StringPool.BLANK %>>
-			<div class="autofit-row autofit-row-center">
-				<div class="autofit-col">
+			<clay:content-row
+				verticalAlign="center"
+			>
+				<clay:content-col>
 					<c:choose>
 						<c:when test="<%= Validator.isNotNull(siteAdministrationPanelCategoryDisplayContext.getLogoURL()) %>">
 							<div class="aspect-ratio-bg-cover sticker" style="background-image: url(<%= siteAdministrationPanelCategoryDisplayContext.getLogoURL() %>);"></div>
@@ -151,9 +153,12 @@ portletURL.setWindowState(LiferayWindowState.EXCLUSIVE);
 							/>
 						</c:otherwise>
 					</c:choose>
-				</div>
+				</clay:content-col>
 
-				<div class="autofit-col autofit-col-expand mr-4">
+				<clay:content-col
+					cssClass="mr-4"
+					expand="true"
+				>
 					<div class="depot-type">
 						<liferay-ui:message key='<%= (group.getType() == GroupConstants.TYPE_DEPOT) ? "asset-library" : "site" %>' />
 					</div>
@@ -165,8 +170,8 @@ portletURL.setWindowState(LiferayWindowState.EXCLUSIVE);
 							<span class="site-sub-name"> - <liferay-ui:message key="<%= siteAdministrationPanelCategoryDisplayContext.getStagingLabel() %>" /></span>
 						</c:if>
 					</div>
-				</div>
-			</div>
+				</clay:content-col>
+			</clay:content-row>
 
 			<c:if test="<%= siteAdministrationPanelCategoryDisplayContext.getNotificationsCount() > 0 %>">
 				<clay:sticker

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/view_site_navigation_menu_item.jsp
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/view_site_navigation_menu_item.jsp
@@ -41,14 +41,19 @@ request.setAttribute("edit_site_navigation_menu.jsp-siteNavigationMenuItemId", s
 		<div class="card card-horizontal taglib-horizontal-card">
 			<div class="card-body site-navigation-menu-item__card">
 				<div class="card-row">
-					<div class="autofit-col site-navigation-menu-item__drag-icon">
+					<clay:content-col
+						cssClass="site-navigation-menu-item__drag-ico"
+					>
 						<liferay-ui:icon
 							icon="drag"
 							markupView="lexicon"
 						/>
-					</div>
+					</clay:content-col>
 
-					<div class="autofit-col autofit-col-expand autofit-col-gutters">
+					<clay:content-col
+						expand="true"
+						gutters="true"
+					>
 						<p class="card-title">
 							<span class="text-truncate">
 								<a href="javascript:;">
@@ -60,7 +65,7 @@ request.setAttribute("edit_site_navigation_menu.jsp-siteNavigationMenuItemId", s
 						<p class="card-subtitle text-truncate">
 							<%= HtmlUtil.escape(siteNavigationMenuItemType.getSubtitle(siteNavigationMenuItem, locale)) %>
 						</p>
-					</div>
+					</clay:content-col>
 				</div>
 
 				<c:if test="<%= siteNavigationAdminDisplayContext.hasUpdatePermission() %>">


### PR DESCRIPTION
This is a simple code replacement, there are 2 important structural changes where we removed some superfluous code
- https://github.com/jbalsas/liferay-portal/pull/2199/files#diff-c25ea9b81bd27b1a429d12dece3f5eb1L102
- https://github.com/jbalsas/liferay-portal/pull/2199/files#diff-29afcb9f88670acce85cf353fd807c32L118

And some cases where we removed the class `autofit-col-end` because we don't have a defined taglib's attribute for it and it resulted unneeded after a deeper examination https://codepen.io/eduardoallegrini/pen/PoZompa?editors=1000
- If we don't use `autofit-float` in the row the `autofit-col-end` in the col won't work https://github.com/liferay/clay/blob/d417c2748b2400c8a516d9d15e79b4e700ba663a/packages/clay-css/src/scss/mixins/_utilities.scss#L12

/cc @marcoscv-work