### PR TITLE
LPS-112470 Updates usage of deprecated clay:navigatoin-bar attributes

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_form_instance.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_form_instance.jsp
@@ -47,8 +47,8 @@ renderResponse.setTitle((formInstance == null) ? LanguageUtil.get(request, "new-
 
 <div class="portlet-forms" id="<portlet:namespace />formContainer">
 	<clay:navigation-bar
-		componentId="formsNavigationBar"
-		elementClasses="forms-management-bar"
+		cssClass="forms-management-bar"
+		id="formsNavigationBar"
 		inverted="<%= true %>"
 		navigationItems="<%= ddmFormAdminDisplayContext.getFormBuilderNavigationItems() %>"
 	/>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/bnd.bnd
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Frontend Taglib Clay
 Bundle-SymbolicName: com.liferay.frontend.taglib.clay
-Bundle-Version: 3.6.0
+Bundle-Version: 4.0.0
 Export-Package:\
 	com.liferay.frontend.taglib.clay.servlet.taglib,\
 	com.liferay.frontend.taglib.clay.servlet.taglib.contributor,\

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
@@ -83,5 +83,5 @@
 		"format": "liferay-npm-scripts fix",
 		"test": "liferay-npm-scripts test"
 	},
-	"version": "3.6.0"
+	"version": "4.0.0"
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/BaseContainerTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/BaseContainerTag.java
@@ -19,20 +19,44 @@ import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
 import com.liferay.petra.string.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
-import com.liferay.taglib.util.IncludeTag;
+import com.liferay.taglib.util.AttributesTagSupport;
 import com.liferay.taglib.util.InlineUtil;
 
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
+import javax.servlet.jsp.JspException;
 import javax.servlet.jsp.JspWriter;
 import javax.servlet.jsp.PageContext;
 
 /**
  * @author Chema Balsas
  */
-public class BaseContainerTag extends IncludeTag {
+public class BaseContainerTag extends AttributesTagSupport {
+
+	@Override
+	public int doEndTag() throws JspException {
+		try {
+			return processEndTag();
+		}
+		catch (Exception exception) {
+			throw new JspException(exception);
+		}
+		finally {
+			doClearTag();
+		}
+	}
+
+	@Override
+	public int doStartTag() throws JspException {
+		try {
+			return processStartTag();
+		}
+		catch (Exception exception) {
+			throw new JspException(exception);
+		}
+	}
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
@@ -165,10 +189,7 @@ public class BaseContainerTag extends IncludeTag {
 		servletContext = ServletContextUtil.getServletContext();
 	}
 
-	@Override
 	protected void cleanUp() {
-		super.cleanUp();
-
 		_componentId = null;
 		_containerElement = null;
 		_contributorKey = null;
@@ -179,9 +200,12 @@ public class BaseContainerTag extends IncludeTag {
 		_id = null;
 	}
 
-	@Override
-	protected boolean isCleanUpSetAttributes() {
-		return _CLEAN_UP_SET_ATTRIBUTES;
+	protected void doClearTag() {
+		clearDynamicAttributes();
+		clearParams();
+		clearProperties();
+
+		cleanUp();
 	}
 
 	/**
@@ -201,7 +225,6 @@ public class BaseContainerTag extends IncludeTag {
 		return StringUtil.merge(cssClasses, StringPool.SPACE);
 	}
 
-	@Override
 	protected int processEndTag() throws Exception {
 		JspWriter jspWriter = pageContext.getOut();
 
@@ -212,7 +235,6 @@ public class BaseContainerTag extends IncludeTag {
 		return EVAL_BODY_INCLUDE;
 	}
 
-	@Override
 	protected int processStartTag() throws Exception {
 		JspWriter jspWriter = pageContext.getOut();
 
@@ -247,8 +269,6 @@ public class BaseContainerTag extends IncludeTag {
 			jspWriter.write(dynamicAttributesString);
 		}
 	}
-
-	private static final boolean _CLEAN_UP_SET_ATTRIBUTES = true;
 
 	private String _componentId;
 	private String _containerElement;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/BaseContainerTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/BaseContainerTag.java
@@ -208,15 +208,6 @@ public class BaseContainerTag extends AttributesTagSupport {
 		cleanUp();
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #processCssClasses(String)}
-	 */
-	@Deprecated
-	protected String processClassName(Set<String> className) {
-		return processCssClasses(className);
-	}
-
 	protected String processCssClasses(Set<String> cssClasses) {
 		if (Validator.isNotNull(_cssClass)) {
 			cssClasses.addAll(StringUtil.split(_cssClass, CharPool.SPACE));

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/BadgeTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/BadgeTag.java
@@ -80,16 +80,6 @@ public class BadgeTag extends BaseContainerTag {
 		_style = null;
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #processCssClasses(String)}
-	 */
-	@Deprecated
-	@Override
-	protected String processClassName(Set<String> className) {
-		return processCssClasses(className);
-	}
-
 	@Override
 	protected String processCssClasses(Set<String> cssClasses) {
 		cssClasses.add("badge");

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/BadgeTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/BadgeTag.java
@@ -80,16 +80,6 @@ public class BadgeTag extends BaseContainerTag {
 		_style = null;
 	}
 
-	@Override
-	protected String getEndPage() {
-		return _END_PAGE;
-	}
-
-	@Override
-	protected String getStartPage() {
-		return _START_PAGE;
-	}
-
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
 	 *             #processCssClasses(String)}
@@ -124,10 +114,6 @@ public class BadgeTag extends BaseContainerTag {
 	}
 
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:badge:";
-
-	private static final String _END_PAGE = "/badge/end.jsp";
-
-	private static final String _START_PAGE = "/badge/start.jsp";
 
 	private String _displayType = "primary";
 	private String _label;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ButtonTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ButtonTag.java
@@ -208,16 +208,6 @@ public class ButtonTag extends BaseContainerTag {
 	}
 
 	@Override
-	protected String getEndPage() {
-		return _END_PAGE;
-	}
-
-	@Override
-	protected String getStartPage() {
-		return _START_PAGE;
-	}
-
-	@Override
 	protected String processCssClasses(Set<String> cssClasses) {
 		cssClasses.add("btn");
 
@@ -297,10 +287,6 @@ public class ButtonTag extends BaseContainerTag {
 	}
 
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:button:";
-
-	private static final String _END_PAGE = "/button/end.jsp";
-
-	private static final String _START_PAGE = "/button/start.jsp";
 
 	private boolean _alert;
 	private String _ariaLabel;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ButtonTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ButtonTag.java
@@ -1,0 +1,318 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.servlet.taglib;
+
+import com.liferay.frontend.taglib.clay.internal.servlet.taglib.BaseContainerTag;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.taglib.util.TagResourceBundleUtil;
+
+import java.util.Set;
+
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.JspWriter;
+
+/**
+ * @author Chema Balsas
+ */
+public class ButtonTag extends BaseContainerTag {
+
+	@Override
+	public int doStartTag() throws JspException {
+		setAttributeNamespace(_ATTRIBUTE_NAMESPACE);
+
+		setContainerElement("button");
+
+		if (Validator.isNotNull(_ariaLabel)) {
+			setDynamicAttribute(StringPool.BLANK, "aria-label", _ariaLabel);
+		}
+
+		if (_disabled) {
+			setDynamicAttribute(StringPool.BLANK, "disabled", _disabled);
+		}
+
+		setDynamicAttribute(StringPool.BLANK, "type", _type);
+
+		return super.doStartTag();
+	}
+
+	public boolean getAlert() {
+		return _alert;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public String getAriaLabel() {
+		return _ariaLabel;
+	}
+
+	public boolean getBlock() {
+		return _block;
+	}
+
+	public boolean getBorderless() {
+		return _borderless;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public boolean getDisabled() {
+		return _disabled;
+	}
+
+	public String getDisplayType() {
+		return _displayType;
+	}
+
+	public String getIcon() {
+		return _icon;
+	}
+
+	public String getLabel() {
+		return _label;
+	}
+
+	public boolean getMonospaced() {
+		return _monospaced;
+	}
+
+	public boolean getOutline() {
+		return _outline;
+	}
+
+	public boolean getSmall() {
+		return _small;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getDisplayType()}
+	 */
+	@Deprecated
+	public String getStyle() {
+		return getDisplayType();
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public String getType() {
+		return _type;
+	}
+
+	public void setAlert(boolean alert) {
+		_alert = alert;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public void setAriaLabel(String ariaLabel) {
+		_ariaLabel = ariaLabel;
+	}
+
+	public void setBlock(boolean block) {
+		_block = block;
+	}
+
+	public void setBorderless(boolean borderless) {
+		_borderless = borderless;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public void setDisabled(boolean disabled) {
+		_disabled = disabled;
+	}
+
+	public void setDisplayType(String displayType) {
+		_displayType = displayType;
+	}
+
+	public void setIcon(String icon) {
+		_icon = icon;
+	}
+
+	public void setLabel(String label) {
+		_label = label;
+	}
+
+	public void setMonospaced(boolean monospaced) {
+		_monospaced = monospaced;
+	}
+
+	public void setOutline(boolean outline) {
+		_outline = outline;
+	}
+
+	public void setSmall(boolean small) {
+		_small = small;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #setDisplayType(String)}
+	 */
+	@Deprecated
+	public void setStyle(String style) {
+		setDisplayType(style);
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public void setType(String type) {
+		_type = type;
+	}
+
+	@Override
+	protected void cleanUp() {
+		super.cleanUp();
+
+		_alert = false;
+		_ariaLabel = null;
+		_block = false;
+		_borderless = false;
+		_disabled = false;
+		_displayType = "primary";
+		_icon = null;
+		_label = null;
+		_monospaced = false;
+		_outline = false;
+		_small = false;
+		_type = "button";
+	}
+
+	@Override
+	protected String getEndPage() {
+		return _END_PAGE;
+	}
+
+	@Override
+	protected String getStartPage() {
+		return _START_PAGE;
+	}
+
+	@Override
+	protected String processCssClasses(Set<String> cssClasses) {
+		cssClasses.add("btn");
+
+		if (_alert) {
+			cssClasses.add("alert-btn");
+		}
+
+		if (_block) {
+			cssClasses.add("btn-block");
+		}
+
+		if (Validator.isNotNull(_icon) || _monospaced) {
+			cssClasses.add("btn-monospaced");
+		}
+
+		if (_borderless) {
+			cssClasses.add("btn-outline-borderless");
+		}
+
+		if (_small) {
+			cssClasses.add("btn-sm");
+		}
+
+		if (Validator.isNotNull(_displayType)) {
+			if (_outline || _borderless) {
+				cssClasses.add("btn-outline-" + _displayType);
+			}
+			else {
+				cssClasses.add("btn-" + _displayType);
+			}
+		}
+
+		return super.processCssClasses(cssClasses);
+	}
+
+	@Override
+	protected int processStartTag() throws Exception {
+		super.processStartTag();
+
+		if (Validator.isNotNull(_icon) || Validator.isNotNull(_label)) {
+			JspWriter jspWriter = pageContext.getOut();
+
+			if (Validator.isNotNull(_icon)) {
+				jspWriter.write("<svg");
+				jspWriter.write(
+					" class=\"lexicon-icon lexicon-icon" + _icon + "\"");
+				jspWriter.write(" role=\"presentation\"");
+				jspWriter.write(" viewBox=\"0 0 512 512\">");
+				jspWriter.write("<use xlink:href=\"");
+
+				ThemeDisplay themeDisplay = (ThemeDisplay)request.getAttribute(
+					WebKeys.THEME_DISPLAY);
+
+				String pathThemeImages = themeDisplay.getPathThemeImages();
+
+				String spritemap = pathThemeImages.concat("/clay/icons.svg");
+
+				jspWriter.write(spritemap);
+
+				jspWriter.write("#");
+				jspWriter.write(_icon);
+				jspWriter.write("\" />");
+				jspWriter.write("</svg>");
+			}
+
+			if (Validator.isNotNull(_label)) {
+				jspWriter.write(
+					LanguageUtil.get(
+						TagResourceBundleUtil.getResourceBundle(pageContext),
+						_label));
+			}
+
+			return SKIP_BODY;
+		}
+
+		return EVAL_BODY_INCLUDE;
+	}
+
+	private static final String _ATTRIBUTE_NAMESPACE = "clay:button:";
+
+	private static final String _END_PAGE = "/button/end.jsp";
+
+	private static final String _START_PAGE = "/button/start.jsp";
+
+	private boolean _alert;
+	private String _ariaLabel;
+	private boolean _block;
+	private boolean _borderless;
+	private boolean _disabled;
+	private String _displayType = "primary";
+	private String _icon;
+	private String _label;
+	private boolean _monospaced;
+	private boolean _outline;
+	private boolean _small;
+	private String _type = "button";
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ColTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ColTag.java
@@ -84,16 +84,6 @@ public class ColTag extends BaseContainerTag {
 		_xl = null;
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #processCssClasses(String)}
-	 */
-	@Deprecated
-	@Override
-	protected String processClassName(Set<String> className) {
-		return processCssClasses(className);
-	}
-
 	@Override
 	protected String processCssClasses(Set<String> cssClasses) {
 		if (Validator.isNotNull(_size)) {

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ColTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ColTag.java
@@ -84,16 +84,6 @@ public class ColTag extends BaseContainerTag {
 		_xl = null;
 	}
 
-	@Override
-	protected String getEndPage() {
-		return _END_PAGE;
-	}
-
-	@Override
-	protected String getStartPage() {
-		return _START_PAGE;
-	}
-
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
 	 *             #processCssClasses(String)}
@@ -134,10 +124,6 @@ public class ColTag extends BaseContainerTag {
 	}
 
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:col:";
-
-	private static final String _END_PAGE = "/col/end.jsp";
-
-	private static final String _START_PAGE = "/col/start.jsp";
 
 	private String _lg;
 	private String _md;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ContainerFluidTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ContainerFluidTag.java
@@ -31,20 +31,6 @@ public class ContainerFluidTag extends ContainerTag {
 		return super.doStartTag();
 	}
 
-	@Override
-	protected String getEndPage() {
-		return _END_PAGE;
-	}
-
-	@Override
-	protected String getStartPage() {
-		return _START_PAGE;
-	}
-
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:container-fluid:";
-
-	private static final String _END_PAGE = "/container_fluid/end.jsp";
-
-	private static final String _START_PAGE = "/container_fluid/start.jsp";
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ContainerTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ContainerTag.java
@@ -57,16 +57,6 @@ public class ContainerTag extends BaseContainerTag {
 		_size = null;
 	}
 
-	@Override
-	protected String getEndPage() {
-		return _END_PAGE;
-	}
-
-	@Override
-	protected String getStartPage() {
-		return _START_PAGE;
-	}
-
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
 	 *             #processCssClasses(String)}
@@ -94,10 +84,6 @@ public class ContainerTag extends BaseContainerTag {
 	}
 
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:container:";
-
-	private static final String _END_PAGE = "/container/end.jsp";
-
-	private static final String _START_PAGE = "/container/start.jsp";
 
 	private boolean _fluid;
 	private String _size;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ContainerTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ContainerTag.java
@@ -57,16 +57,6 @@ public class ContainerTag extends BaseContainerTag {
 		_size = null;
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #processCssClasses(String)}
-	 */
-	@Deprecated
-	@Override
-	protected String processClassName(Set<String> className) {
-		return processCssClasses(className);
-	}
-
 	@Override
 	protected String processCssClasses(Set<String> cssClasses) {
 		if (!_fluid) {

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ContentColTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ContentColTag.java
@@ -56,16 +56,6 @@ public class ContentColTag extends BaseContainerTag {
 		_gutters = false;
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #processCssClasses(String)}
-	 */
-	@Deprecated
-	@Override
-	protected String processClassName(Set<String> className) {
-		return processCssClasses(className);
-	}
-
 	@Override
 	protected String processCssClasses(Set<String> cssClasses) {
 		cssClasses.add("autofit-col");

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ContentColTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ContentColTag.java
@@ -56,16 +56,6 @@ public class ContentColTag extends BaseContainerTag {
 		_gutters = false;
 	}
 
-	@Override
-	protected String getEndPage() {
-		return _END_PAGE;
-	}
-
-	@Override
-	protected String getStartPage() {
-		return _START_PAGE;
-	}
-
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
 	 *             #processCssClasses(String)}
@@ -92,10 +82,6 @@ public class ContentColTag extends BaseContainerTag {
 	}
 
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:content-col:";
-
-	private static final String _END_PAGE = "/content_col/end.jsp";
-
-	private static final String _START_PAGE = "/content_col/start.jsp";
 
 	private boolean _expand;
 	private boolean _gutters;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ContentRowTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ContentRowTag.java
@@ -76,16 +76,6 @@ public class ContentRowTag extends BaseContainerTag {
 		_verticalAlign = null;
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #processCssClasses(String)}
-	 */
-	@Deprecated
-	@Override
-	protected String processClassName(Set<String> className) {
-		return processCssClasses(className);
-	}
-
 	@Override
 	protected String processCssClasses(Set<String> cssClasses) {
 		cssClasses.add("autofit-row");

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ContentRowTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ContentRowTag.java
@@ -76,16 +76,6 @@ public class ContentRowTag extends BaseContainerTag {
 		_verticalAlign = null;
 	}
 
-	@Override
-	protected String getEndPage() {
-		return _END_PAGE;
-	}
-
-	@Override
-	protected String getStartPage() {
-		return _START_PAGE;
-	}
-
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
 	 *             #processCssClasses(String)}
@@ -130,10 +120,6 @@ public class ContentRowTag extends BaseContainerTag {
 	}
 
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:content-row:";
-
-	private static final String _END_PAGE = "/content_row/end.jsp";
-
-	private static final String _START_PAGE = "/content_row/start.jsp";
 
 	private String _floatElements;
 	private String _noGutters;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ContentSectionTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ContentSectionTag.java
@@ -32,16 +32,6 @@ public class ContentSectionTag extends BaseContainerTag {
 		return super.doStartTag();
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #processCssClasses(String)}
-	 */
-	@Deprecated
-	@Override
-	protected String processClassName(Set<String> className) {
-		return processCssClasses(className);
-	}
-
 	@Override
 	protected String processCssClasses(Set<String> cssClasses) {
 		cssClasses.add("autofit-section");

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ContentSectionTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ContentSectionTag.java
@@ -32,16 +32,6 @@ public class ContentSectionTag extends BaseContainerTag {
 		return super.doStartTag();
 	}
 
-	@Override
-	protected String getEndPage() {
-		return _END_PAGE;
-	}
-
-	@Override
-	protected String getStartPage() {
-		return _START_PAGE;
-	}
-
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
 	 *             #processCssClasses(String)}
@@ -60,9 +50,5 @@ public class ContentSectionTag extends BaseContainerTag {
 	}
 
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:content-section:";
-
-	private static final String _END_PAGE = "/content_section/end.jsp";
-
-	private static final String _START_PAGE = "/content_section/start.jsp";
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/IconTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/IconTag.java
@@ -97,16 +97,6 @@ public class IconTag extends BaseContainerTag {
 		_symbol = null;
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #processCssClasses(String)}
-	 */
-	@Deprecated
-	@Override
-	protected String processClassName(Set<String> className) {
-		return processCssClasses(className);
-	}
-
 	@Override
 	protected String processCssClasses(Set<String> cssClasses) {
 		cssClasses.add("lexicon-icon");

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/IconTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/IconTag.java
@@ -97,16 +97,6 @@ public class IconTag extends BaseContainerTag {
 		_symbol = null;
 	}
 
-	@Override
-	protected String getEndPage() {
-		return _END_PAGE;
-	}
-
-	@Override
-	protected String getStartPage() {
-		return _START_PAGE;
-	}
-
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
 	 *             #processCssClasses(String)}
@@ -141,10 +131,6 @@ public class IconTag extends BaseContainerTag {
 	}
 
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:icon:";
-
-	private static final String _END_PAGE = "/icon/end.jsp";
-
-	private static final String _START_PAGE = "/icon/start.jsp";
 
 	private boolean _monospaced;
 	private String _spritemap;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LabelItemAfterTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LabelItemAfterTag.java
@@ -36,16 +36,6 @@ public class LabelItemAfterTag extends BaseContainerTag {
 		return super.doStartTag();
 	}
 
-	@Override
-	protected String getEndPage() {
-		return _END_PAGE;
-	}
-
-	@Override
-	protected String getStartPage() {
-		return _START_PAGE;
-	}
-
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
 	 *             #processCssClasses(String)}
@@ -65,9 +55,5 @@ public class LabelItemAfterTag extends BaseContainerTag {
 	}
 
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:label-item-after:";
-
-	private static final String _END_PAGE = "/label_item_after/end.jsp";
-
-	private static final String _START_PAGE = "/label_item_after/start.jsp";
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LabelItemAfterTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LabelItemAfterTag.java
@@ -36,16 +36,6 @@ public class LabelItemAfterTag extends BaseContainerTag {
 		return super.doStartTag();
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #processCssClasses(String)}
-	 */
-	@Deprecated
-	@Override
-	protected String processClassName(Set<String> className) {
-		return processCssClasses(className);
-	}
-
 	@Override
 	protected String processCssClasses(Set<String> cssClasses) {
 		cssClasses.add("label-item");

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LabelItemBeforeTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LabelItemBeforeTag.java
@@ -36,16 +36,6 @@ public class LabelItemBeforeTag extends BaseContainerTag {
 		return super.doStartTag();
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #processCssClasses(String)}
-	 */
-	@Deprecated
-	@Override
-	protected String processClassName(Set<String> className) {
-		return processCssClasses(className);
-	}
-
 	@Override
 	protected String processCssClasses(Set<String> cssClasses) {
 		cssClasses.add("label-item");

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LabelItemBeforeTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LabelItemBeforeTag.java
@@ -36,16 +36,6 @@ public class LabelItemBeforeTag extends BaseContainerTag {
 		return super.doStartTag();
 	}
 
-	@Override
-	protected String getEndPage() {
-		return _END_PAGE;
-	}
-
-	@Override
-	protected String getStartPage() {
-		return _START_PAGE;
-	}
-
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
 	 *             #processCssClasses(String)}
@@ -66,9 +56,5 @@ public class LabelItemBeforeTag extends BaseContainerTag {
 
 	private static final String _ATTRIBUTE_NAMESPACE =
 		"clay:label-item-before:";
-
-	private static final String _END_PAGE = "/label_item_before/end.jsp";
-
-	private static final String _START_PAGE = "/label_item_before/start.jsp";
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LabelItemExpandTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LabelItemExpandTag.java
@@ -36,16 +36,6 @@ public class LabelItemExpandTag extends BaseContainerTag {
 		return super.doStartTag();
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #processCssClasses(String)}
-	 */
-	@Deprecated
-	@Override
-	protected String processClassName(Set<String> className) {
-		return processCssClasses(className);
-	}
-
 	@Override
 	protected String processCssClasses(Set<String> cssClasses) {
 		cssClasses.add("label-item");

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LabelItemExpandTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LabelItemExpandTag.java
@@ -36,16 +36,6 @@ public class LabelItemExpandTag extends BaseContainerTag {
 		return super.doStartTag();
 	}
 
-	@Override
-	protected String getEndPage() {
-		return _END_PAGE;
-	}
-
-	@Override
-	protected String getStartPage() {
-		return _START_PAGE;
-	}
-
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
 	 *             #processCssClasses(String)}
@@ -66,9 +56,5 @@ public class LabelItemExpandTag extends BaseContainerTag {
 
 	private static final String _ATTRIBUTE_NAMESPACE =
 		"clay:label-item-expand:";
-
-	private static final String _END_PAGE = "/label_item_expand/end.jsp";
-
-	private static final String _START_PAGE = "/label_item_expand/start.jsp";
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LabelTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LabelTag.java
@@ -191,16 +191,6 @@ public class LabelTag extends BaseContainerTag {
 		_spritemap = null;
 	}
 
-	@Override
-	protected String getEndPage() {
-		return _END_PAGE;
-	}
-
-	@Override
-	protected String getStartPage() {
-		return _START_PAGE;
-	}
-
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
 	 *             #processCssClasses(String)}
@@ -265,10 +255,6 @@ public class LabelTag extends BaseContainerTag {
 	}
 
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:label:";
-
-	private static final String _END_PAGE = "/label/end.jsp";
-
-	private static final String _START_PAGE = "/label/start.jsp";
 
 	private boolean _dismissible;
 	private String _displayType = "secondary";

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LabelTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LabelTag.java
@@ -191,16 +191,6 @@ public class LabelTag extends BaseContainerTag {
 		_spritemap = null;
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #processCssClasses(String)}
-	 */
-	@Deprecated
-	@Override
-	protected String processClassName(Set<String> className) {
-		return processCssClasses(className);
-	}
-
 	@Override
 	protected String processCssClasses(Set<String> cssClasses) {
 		cssClasses.add("label");

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/NavigationBarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/NavigationBarTag.java
@@ -1,0 +1,162 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.servlet.taglib;
+
+import com.liferay.frontend.taglib.clay.internal.servlet.taglib.BaseContainerTag;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItem;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.List;
+import java.util.Set;
+
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.JspWriter;
+
+/**
+ * @author Chema Balsas
+ */
+public class NavigationBarTag extends BaseContainerTag {
+
+	@Override
+	public int doStartTag() throws JspException {
+		setAttributeNamespace(_ATTRIBUTE_NAMESPACE);
+
+		setContainerElement("nav");
+
+		return super.doStartTag();
+	}
+
+	public boolean getInverted() {
+		return _inverted;
+	}
+
+	public List<NavigationItem> getNavigationItems() {
+		return _navigationItems;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public String getSpritemap() {
+		return _spritemap;
+	}
+
+	public void setInverted(boolean inverted) {
+		_inverted = inverted;
+	}
+
+	public void setNavigationItems(List<NavigationItem> navigationItems) {
+		_navigationItems = navigationItems;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 */
+	@Deprecated
+	public void setSpritemap(String spritemap) {
+		_spritemap = spritemap;
+	}
+
+	@Override
+	protected void cleanUp() {
+		super.cleanUp();
+
+		_inverted = false;
+		_navigationItems = null;
+		_spritemap = null;
+	}
+
+	@Override
+	protected String processCssClasses(Set<String> cssClasses) {
+		cssClasses.add("navbar");
+		cssClasses.add("navbar-collapse-absolute");
+		cssClasses.add("navbar-expand-md");
+		cssClasses.add("navbar-underline");
+		cssClasses.add("navigation-bar");
+
+		cssClasses.add(
+			_inverted ? "navigation-bar-secondary" : "navigation-bar-light");
+
+		return super.processCssClasses(cssClasses);
+	}
+
+	@Override
+	protected int processStartTag() throws Exception {
+		super.processStartTag();
+
+		if (_navigationItems != null) {
+			JspWriter jspWriter = pageContext.getOut();
+
+			jspWriter.write(
+				"<div class=\"container-fluid container-fluid-max-xl\">");
+
+			jspWriter.write("<div class=\"collapse navbar-collapse\">");
+
+			jspWriter.write(
+				"<div class=\"container-fluid container-fluid-max-xl\">");
+
+			jspWriter.write("<ul class=\"navbar-nav\">");
+
+			for (int i = 0; i < _navigationItems.size(); i++) {
+				NavigationItem navigationItem = _navigationItems.get(i);
+
+				jspWriter.write("<li class=\"nav-item\"");
+				jspWriter.write(" data-nav-item-index=\"");
+				jspWriter.write(String.valueOf(i));
+				jspWriter.write("\">");
+				jspWriter.write("<a class=\"nav-link");
+
+				if ((navigationItem.get("active") != null) &&
+					(Boolean)navigationItem.get("active")) {
+
+					jspWriter.write(" active");
+				}
+
+				jspWriter.write("\"");
+
+				if (Validator.isNotNull((String)navigationItem.get("href"))) {
+					jspWriter.write(" href=\"");
+					jspWriter.write((String)navigationItem.get("href"));
+					jspWriter.write("\"");
+				}
+
+				jspWriter.write(">");
+
+				jspWriter.write("<span class=\"navbar-text-truncate\">");
+				jspWriter.write((String)navigationItem.get("label"));
+				jspWriter.write("</span>");
+				jspWriter.write("</a>");
+				jspWriter.write("</li>");
+			}
+
+			jspWriter.write("</ul>");
+			jspWriter.write("</div>");
+			jspWriter.write("</div>");
+			jspWriter.write("</div>");
+
+			return SKIP_BODY;
+		}
+
+		return EVAL_BODY_INCLUDE;
+	}
+
+	private static final String _ATTRIBUTE_NAMESPACE = "clay:navigation_bar:";
+
+	private boolean _inverted;
+	private List<NavigationItem> _navigationItems;
+	private String _spritemap;
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/RowTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/RowTag.java
@@ -32,16 +32,6 @@ public class RowTag extends BaseContainerTag {
 		return super.doStartTag();
 	}
 
-	@Override
-	protected String getEndPage() {
-		return _END_PAGE;
-	}
-
-	@Override
-	protected String getStartPage() {
-		return _START_PAGE;
-	}
-
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
 	 *             #processCssClasses(String)}
@@ -60,9 +50,5 @@ public class RowTag extends BaseContainerTag {
 	}
 
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:row:";
-
-	private static final String _END_PAGE = "/row/end.jsp";
-
-	private static final String _START_PAGE = "/row/start.jsp";
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/RowTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/RowTag.java
@@ -32,16 +32,6 @@ public class RowTag extends BaseContainerTag {
 		return super.doStartTag();
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #processCssClasses(String)}
-	 */
-	@Deprecated
-	@Override
-	protected String processClassName(Set<String> className) {
-		return processCssClasses(className);
-	}
-
 	@Override
 	protected String processCssClasses(Set<String> cssClasses) {
 		cssClasses.add("row");

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/SheetFooterTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/SheetFooterTag.java
@@ -32,16 +32,6 @@ public class SheetFooterTag extends BaseContainerTag {
 		return super.doStartTag();
 	}
 
-	@Override
-	protected String getEndPage() {
-		return _END_PAGE;
-	}
-
-	@Override
-	protected String getStartPage() {
-		return _START_PAGE;
-	}
-
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
 	 *             #processCssClasses(String)}
@@ -60,9 +50,5 @@ public class SheetFooterTag extends BaseContainerTag {
 	}
 
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:sheet-footer:";
-
-	private static final String _END_PAGE = "/sheet_footer/end.jsp";
-
-	private static final String _START_PAGE = "/sheet_footer/start.jsp";
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/SheetFooterTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/SheetFooterTag.java
@@ -32,16 +32,6 @@ public class SheetFooterTag extends BaseContainerTag {
 		return super.doStartTag();
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #processCssClasses(String)}
-	 */
-	@Deprecated
-	@Override
-	protected String processClassName(Set<String> className) {
-		return processCssClasses(className);
-	}
-
 	@Override
 	protected String processCssClasses(Set<String> cssClasses) {
 		cssClasses.add("sheet-footer");

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/SheetHeaderTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/SheetHeaderTag.java
@@ -32,16 +32,6 @@ public class SheetHeaderTag extends BaseContainerTag {
 		return super.doStartTag();
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #processCssClasses(String)}
-	 */
-	@Deprecated
-	@Override
-	protected String processClassName(Set<String> className) {
-		return processCssClasses(className);
-	}
-
 	@Override
 	protected String processCssClasses(Set<String> cssClasses) {
 		cssClasses.add("sheet-header");

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/SheetHeaderTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/SheetHeaderTag.java
@@ -32,16 +32,6 @@ public class SheetHeaderTag extends BaseContainerTag {
 		return super.doStartTag();
 	}
 
-	@Override
-	protected String getEndPage() {
-		return _END_PAGE;
-	}
-
-	@Override
-	protected String getStartPage() {
-		return _START_PAGE;
-	}
-
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
 	 *             #processCssClasses(String)}
@@ -60,9 +50,5 @@ public class SheetHeaderTag extends BaseContainerTag {
 	}
 
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:sheet-header:";
-
-	private static final String _END_PAGE = "/sheet_header/end.jsp";
-
-	private static final String _START_PAGE = "/sheet_header/start.jsp";
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/SheetSectionTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/SheetSectionTag.java
@@ -32,16 +32,6 @@ public class SheetSectionTag extends BaseContainerTag {
 		return super.doStartTag();
 	}
 
-	@Override
-	protected String getEndPage() {
-		return _END_PAGE;
-	}
-
-	@Override
-	protected String getStartPage() {
-		return _START_PAGE;
-	}
-
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
 	 *             #processCssClasses(String)}
@@ -60,9 +50,5 @@ public class SheetSectionTag extends BaseContainerTag {
 	}
 
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:sheet-section:";
-
-	private static final String _END_PAGE = "/sheet_section/end.jsp";
-
-	private static final String _START_PAGE = "/sheet_section/start.jsp";
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/SheetSectionTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/SheetSectionTag.java
@@ -32,16 +32,6 @@ public class SheetSectionTag extends BaseContainerTag {
 		return super.doStartTag();
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #processCssClasses(String)}
-	 */
-	@Deprecated
-	@Override
-	protected String processClassName(Set<String> className) {
-		return processCssClasses(className);
-	}
-
 	@Override
 	protected String processCssClasses(Set<String> cssClasses) {
 		cssClasses.add("sheet-section");

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/SheetTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/SheetTag.java
@@ -48,16 +48,6 @@ public class SheetTag extends BaseContainerTag {
 		_size = "lg";
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #processCssClasses(String)}
-	 */
-	@Deprecated
-	@Override
-	protected String processClassName(Set<String> className) {
-		return processCssClasses(className);
-	}
-
 	@Override
 	protected String processCssClasses(Set<String> cssClasses) {
 		cssClasses.add("sheet");

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/SheetTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/SheetTag.java
@@ -48,16 +48,6 @@ public class SheetTag extends BaseContainerTag {
 		_size = "lg";
 	}
 
-	@Override
-	protected String getEndPage() {
-		return _END_PAGE;
-	}
-
-	@Override
-	protected String getStartPage() {
-		return _START_PAGE;
-	}
-
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
 	 *             #processCssClasses(String)}
@@ -80,10 +70,6 @@ public class SheetTag extends BaseContainerTag {
 	}
 
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:sheet:";
-
-	private static final String _END_PAGE = "/sheet/end.jsp";
-
-	private static final String _START_PAGE = "/sheet/start.jsp";
 
 	private String _size = "lg";
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/StickerTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/StickerTag.java
@@ -159,16 +159,6 @@ public class StickerTag extends BaseContainerTag {
 		_spritemap = null;
 	}
 
-	@Override
-	protected String getEndPage() {
-		return _END_PAGE;
-	}
-
-	@Override
-	protected String getStartPage() {
-		return _START_PAGE;
-	}
-
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
 	 *             #processCssClasses(String)}
@@ -243,10 +233,6 @@ public class StickerTag extends BaseContainerTag {
 	}
 
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:sticker:";
-
-	private static final String _END_PAGE = "/sticker/end.jsp";
-
-	private static final String _START_PAGE = "/sticker/start.jsp";
 
 	private String _displayType;
 	private String _icon;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/StickerTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/StickerTag.java
@@ -159,16 +159,6 @@ public class StickerTag extends BaseContainerTag {
 		_spritemap = null;
 	}
 
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *             #processCssClasses(String)}
-	 */
-	@Deprecated
-	@Override
-	protected String processClassName(Set<String> className) {
-		return processCssClasses(className);
-	}
-
 	@Override
 	protected String processCssClasses(Set<String> cssClasses) {
 		cssClasses.add("sticker");

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -1993,34 +1993,40 @@
 	<tag>
 		<description></description>
 		<name>navigation-bar</name>
-		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.soy.NavigationBarTag</tag-class>
+		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.NavigationBarTag</tag-class>
 		<body-content>empty</body-content>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>componentId</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>contributorKey</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
 			<description></description>
+			<name>cssClass</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>data</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>defaultEventHandler</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, replaced by the attribute <![CDATA[<code>cssClass</code>]]>.</description>
 			<name>elementClasses</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -2044,7 +2050,7 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
+			<description>Deprecated as of 7.3.0, with no direct replacement.</description>
 			<name>spritemap</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/badge/end.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/badge/end.jsp.readme
@@ -1,3 +1,0 @@
-The content of this JSP file was inlined to improve performance. To use your own
-content instead, remove the ".readme" extension and add your content to this
-file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/badge/start.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/badge/start.jsp.readme
@@ -1,3 +1,0 @@
-The content of this JSP file was inlined to improve performance. To use your own
-content instead, remove the ".readme" extension and add your content to this
-file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/col/end.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/col/end.jsp.readme
@@ -1,3 +1,0 @@
-The content of this JSP file was inlined to improve performance. To use your own
-content instead, remove the ".readme" extension and add your content to this
-file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/col/start.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/col/start.jsp.readme
@@ -1,3 +1,0 @@
-The content of this JSP file was inlined to improve performance. To use your own
-content instead, remove the ".readme" extension and add your content to this
-file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/container/end.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/container/end.jsp.readme
@@ -1,3 +1,0 @@
-The content of this JSP file was inlined to improve performance. To use your own
-content instead, remove the ".readme" extension and add your content to this
-file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/container/start.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/container/start.jsp.readme
@@ -1,3 +1,0 @@
-The content of this JSP file was inlined to improve performance. To use your own
-content instead, remove the ".readme" extension and add your content to this
-file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/container_fluid/end.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/container_fluid/end.jsp.readme
@@ -1,3 +1,0 @@
-The content of this JSP file was inlined to improve performance. To use your own
-content instead, remove the ".readme" extension and add your content to this
-file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/container_fluid/start.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/container_fluid/start.jsp.readme
@@ -1,3 +1,0 @@
-The content of this JSP file was inlined to improve performance. To use your own
-content instead, remove the ".readme" extension and add your content to this
-file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/content_col/end.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/content_col/end.jsp.readme
@@ -1,3 +1,0 @@
-The content of this JSP file was inlined to improve performance. To use your own
-content instead, remove the ".readme" extension and add your content to this
-file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/content_col/start.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/content_col/start.jsp.readme
@@ -1,3 +1,0 @@
-The content of this JSP file was inlined to improve performance. To use your own
-content instead, remove the ".readme" extension and add your content to this
-file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/content_row/end.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/content_row/end.jsp.readme
@@ -1,3 +1,0 @@
-The content of this JSP file was inlined to improve performance. To use your own
-content instead, remove the ".readme" extension and add your content to this
-file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/content_row/start.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/content_row/start.jsp.readme
@@ -1,3 +1,0 @@
-The content of this JSP file was inlined to improve performance. To use your own
-content instead, remove the ".readme" extension and add your content to this
-file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/content_section/end.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/content_section/end.jsp.readme
@@ -1,3 +1,0 @@
-The content of this JSP file was inlined to improve performance. To use your own
-content instead, remove the ".readme" extension and add your content to this
-file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/content_section/start.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/content_section/start.jsp.readme
@@ -1,3 +1,0 @@
-The content of this JSP file was inlined to improve performance. To use your own
-content instead, remove the ".readme" extension and add your content to this
-file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/icon/end.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/icon/end.jsp.readme
@@ -1,3 +1,0 @@
-The content of this JSP file was inlined to improve performance. To use your own
-content instead, remove the ".readme" extension and add your content to this
-file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/icon/start.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/icon/start.jsp.readme
@@ -1,3 +1,0 @@
-The content of this JSP file was inlined to improve performance. To use your own
-content instead, remove the ".readme" extension and add your content to this
-file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/label/end.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/label/end.jsp.readme
@@ -1,3 +1,0 @@
-The content of this JSP file was inlined to improve performance. To use your own
-content instead, remove the ".readme" extension and add your content to this
-file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/label/start.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/label/start.jsp.readme
@@ -1,3 +1,0 @@
-The content of this JSP file was inlined to improve performance. To use your own
-content instead, remove the ".readme" extension and add your content to this
-file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/label_item_after/end.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/label_item_after/end.jsp.readme
@@ -1,3 +1,0 @@
-The content of this JSP file was inlined to improve performance. To use your own
-content instead, remove the ".readme" extension and add your content to this
-file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/label_item_after/start.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/label_item_after/start.jsp.readme
@@ -1,3 +1,0 @@
-The content of this JSP file was inlined to improve performance. To use your own
-content instead, remove the ".readme" extension and add your content to this
-file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/label_item_before/end.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/label_item_before/end.jsp.readme
@@ -1,3 +1,0 @@
-The content of this JSP file was inlined to improve performance. To use your own
-content instead, remove the ".readme" extension and add your content to this
-file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/label_item_before/start.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/label_item_before/start.jsp.readme
@@ -1,3 +1,0 @@
-The content of this JSP file was inlined to improve performance. To use your own
-content instead, remove the ".readme" extension and add your content to this
-file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/label_item_expand/end.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/label_item_expand/end.jsp.readme
@@ -1,3 +1,0 @@
-The content of this JSP file was inlined to improve performance. To use your own
-content instead, remove the ".readme" extension and add your content to this
-file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/label_item_expand/start.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/label_item_expand/start.jsp.readme
@@ -1,3 +1,0 @@
-The content of this JSP file was inlined to improve performance. To use your own
-content instead, remove the ".readme" extension and add your content to this
-file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/row/end.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/row/end.jsp.readme
@@ -1,3 +1,0 @@
-The content of this JSP file was inlined to improve performance. To use your own
-content instead, remove the ".readme" extension and add your content to this
-file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/row/start.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/row/start.jsp.readme
@@ -1,3 +1,0 @@
-The content of this JSP file was inlined to improve performance. To use your own
-content instead, remove the ".readme" extension and add your content to this
-file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/sheet/end.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/sheet/end.jsp.readme
@@ -1,3 +1,0 @@
-The content of this JSP file was inlined to improve performance. To use your own
-content instead, remove the ".readme" extension and add your content to this
-file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/sheet/start.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/sheet/start.jsp.readme
@@ -1,3 +1,0 @@
-The content of this JSP file was inlined to improve performance. To use your own
-content instead, remove the ".readme" extension and add your content to this
-file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/sheet_footer/end.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/sheet_footer/end.jsp.readme
@@ -1,3 +1,0 @@
-The content of this JSP file was inlined to improve performance. To use your own
-content instead, remove the ".readme" extension and add your content to this
-file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/sheet_footer/start.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/sheet_footer/start.jsp.readme
@@ -1,3 +1,0 @@
-The content of this JSP file was inlined to improve performance. To use your own
-content instead, remove the ".readme" extension and add your content to this
-file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/sheet_header/end.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/sheet_header/end.jsp.readme
@@ -1,3 +1,0 @@
-The content of this JSP file was inlined to improve performance. To use your own
-content instead, remove the ".readme" extension and add your content to this
-file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/sheet_header/start.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/sheet_header/start.jsp.readme
@@ -1,3 +1,0 @@
-The content of this JSP file was inlined to improve performance. To use your own
-content instead, remove the ".readme" extension and add your content to this
-file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/sheet_section/end.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/sheet_section/end.jsp.readme
@@ -1,3 +1,0 @@
-The content of this JSP file was inlined to improve performance. To use your own
-content instead, remove the ".readme" extension and add your content to this
-file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/sheet_section/start.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/sheet_section/start.jsp.readme
@@ -1,3 +1,0 @@
-The content of this JSP file was inlined to improve performance. To use your own
-content instead, remove the ".readme" extension and add your content to this
-file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/sticker/end.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/sticker/end.jsp.readme
@@ -1,3 +1,0 @@
-The content of this JSP file was inlined to improve performance. To use your own
-content instead, remove the ".readme" extension and add your content to this
-file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/sticker/start.jsp.readme
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/sticker/start.jsp.readme
@@ -1,3 +1,0 @@
-The content of this JSP file was inlined to improve performance. To use your own
-content instead, remove the ".readme" extension and add your content to this
-file.

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/com/liferay/frontend/taglib/clay/servlet/taglib/packageinfo
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/com/liferay/frontend/taglib/clay/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 2.0.0

--- a/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view.jsp
@@ -40,7 +40,7 @@ List<NavigationItem> navigationItems = localizedItemSelectorRendering.getNavigat
 	<c:otherwise>
 		<c:if test="<%= navigationItems.size() > 1 %>">
 			<clay:navigation-bar
-				elementClasses="border-bottom"
+				cssClass="border-bottom"
 				inverted="<%= false %>"
 				navigationItems="<%= navigationItems %>"
 			/>


### PR DESCRIPTION
This PR contains:

### Performance Improvements
- Flattened class hierarchy to avoid `IncludeTag` overhead. **This forces a major version bump**. We can keep all the methods, but changing parent class is a major, so not much we can do... since these tags were recently added, I'd expect we should be able to keep current version, but not sure how one thing or the other would affect us.

### `clay:button`
- New Tag Java Class
- Legacy tag attribute deprecation 
- Legacy tag implementation deprecation

I didn't go with the whole `tag` migration process since we're still running perf tests and I want to make sure it's safe before applying this change globally.

### `clay:navigation-bar`
- Tag migration
- Legacy tag attribute deprecation 
- Legacy tag implementation deprecation