### PR TITLE
LPS-114087 Replace layout classes with new clay components in site-navigation

### DIFF
--- a/modules/apps/asset/asset-categories-selector-web/package.json
+++ b/modules/apps/asset/asset-categories-selector-web/package.json
@@ -1,6 +1,7 @@
 {
 	"dependencies": {
 		"@clayui/icon": "3.0.5",
+		"@clayui/layout": "3.0.1",
 		"frontend-js-components-web": "*",
 		"frontend-js-web": "*"
 	},

--- a/modules/apps/asset/asset-categories-selector-web/src/main/resources/META-INF/resources/js/SelectCategory.es.js
+++ b/modules/apps/asset/asset-categories-selector-web/src/main/resources/META-INF/resources/js/SelectCategory.es.js
@@ -13,6 +13,7 @@
  */
 
 import ClayIcon from '@clayui/icon';
+import ClayLayout from '@clayui/layout';
 import {Treeview} from 'frontend-js-components-web';
 import React, {useCallback, useRef, useState} from 'react';
 
@@ -87,7 +88,7 @@ function SelectCategory({
 	return (
 		<div className="select-category">
 			<form className="select-category-filter" role="search">
-				<div className="container-fluid-1280">
+				<ClayLayout.ContainerFluid>
 					<div className="input-group">
 						<div className="input-group-item">
 							<input
@@ -102,11 +103,11 @@ function SelectCategory({
 							</div>
 						</div>
 					</div>
-				</div>
+				</ClayLayout.ContainerFluid>
 			</form>
 
 			<form name={`${namespace}selectCategoryFm`}>
-				<fieldset className="container-fluid-1280">
+				<ClayLayout.ContainerFluid containerElement="fieldset">
 					<div
 						className="category-tree"
 						id={`${namespace}categoryContainer`}
@@ -120,7 +121,7 @@ function SelectCategory({
 							onSelectedNodesChange={handleSelectionChange}
 						/>
 					</div>
-				</fieldset>
+				</ClayLayout.ContainerFluid>
 			</form>
 		</div>
 	);

--- a/modules/apps/product-navigation/product-navigation-global-menu-web/package.json
+++ b/modules/apps/product-navigation/product-navigation-global-menu-web/package.json
@@ -3,6 +3,7 @@
 		"@clayui/button": "3.3.1",
 		"@clayui/drop-down": "3.4.3",
 		"@clayui/icon": "3.0.5",
+		"@clayui/layout": "3.0.1",
 		"@clayui/sticker": "3.1.1",
 		"frontend-js-web": "*",
 		"prop-types": "15.7.2",

--- a/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/js/GlobalMenu.js
+++ b/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/js/GlobalMenu.js
@@ -13,6 +13,7 @@
  */
 
 import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
+import ClayLayout from '@clayui/layout';
 
 import 'product-navigation-global-apps/css/GlobalMenu.scss';
 import ClaySticker from '@clayui/sticker';
@@ -52,7 +53,7 @@ const AppsPanel = ({categories = [], portletNamespace, sites}) => {
 
 	return (
 		<>
-			<div className="c-px-md-4 row">
+			<ClayLayout.Row className="c-px-md-4">
 				<ClayTabs modern>
 					{categories.map(({key, label}, index) => (
 						<ClayTabs.Item
@@ -65,7 +66,7 @@ const AppsPanel = ({categories = [], portletNamespace, sites}) => {
 						</ClayTabs.Item>
 					))}
 				</ClayTabs>
-			</div>
+			</ClayLayout.Row>
 
 			<ClayTabs.Content activeIndex={activeTab}>
 				{categories.map(({childCategories}, index) => (
@@ -74,9 +75,9 @@ const AppsPanel = ({categories = [], portletNamespace, sites}) => {
 						className={'global-menu__tab-pane'}
 						key={`tabPane-${index}`}
 					>
-						<div className="c-p-md-3 row">
+						<ClayLayout.Row className="c-p-md-3">
 							{childCategories.map(({key, label, panelApps}) => (
-								<div className="col-md" key={key}>
+								<ClayLayout.Col key={key} md>
 									<ul className="list-unstyled">
 										<li className="dropdown-subheader">
 											{label}
@@ -95,10 +96,10 @@ const AppsPanel = ({categories = [], portletNamespace, sites}) => {
 											)
 										)}
 									</ul>
-								</div>
+								</ClayLayout.Col>
 							))}
 
-							<div className="col-md">
+							<ClayLayout.Col md>
 								<ul className="bg-light list-unstyled rounded">
 									<li className="dropdown-subheader">
 										{Liferay.Language.get('sites')}
@@ -154,8 +155,8 @@ const AppsPanel = ({categories = [], portletNamespace, sites}) => {
 										</li>
 									)}
 								</ul>
-							</div>
-						</div>
+							</ClayLayout.Col>
+						</ClayLayout.Row>
 					</ClayTabs.TabPane>
 				))}
 			</ClayTabs.Content>

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/PageTypeSelector.es.js
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/PageTypeSelector.es.js
@@ -78,31 +78,21 @@ function PageTypeSelector(props) {
 					<ClayDropDown.ItemList>
 						{props.addLayoutURL !== '' && (
 							<ClayDropDown.Item
-								className="autofit-row"
 								data-value={Liferay.Language.get('add-page')}
 								key={Liferay.Language.get('add-page')}
 								onClick={handleOnAddPageClick}
 								title={Liferay.Language.get('add-page')}
 							>
-								<span className="autofit-col autofit-col-expand">
-									<span className="autofit-section">
-										{Liferay.Language.get('add-page')}
-									</span>
-								</span>
+								{Liferay.Language.get('add-page')}
 							</ClayDropDown.Item>
 						)}
 						<ClayDropDown.Item
-							className="autofit-row"
 							data-value={Liferay.Language.get('configure')}
 							key={Liferay.Language.get('configure')}
 							onClick={handleOnConfigureClick}
 							title={Liferay.Language.get('configure')}
 						>
-							<span className="autofit-col autofit-col-expand">
-								<span className="autofit-section">
-									{Liferay.Language.get('configure')}
-								</span>
-							</span>
+							{Liferay.Language.get('configure')}
 						</ClayDropDown.Item>
 					</ClayDropDown.ItemList>
 				</ClayDropDown>

--- a/modules/apps/ratings/ratings-taglib/package.json
+++ b/modules/apps/ratings/ratings-taglib/package.json
@@ -2,6 +2,7 @@
 	"dependencies": {
 		"@clayui/button": "3.3.1",
 		"@clayui/icon": "3.0.5",
+		"@clayui/layout": "3.0.1",
 		"prop-types": "15.7.2",
 		"react": "16.12.0"
 	},

--- a/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/js/components/RatingsStars.js
+++ b/modules/apps/ratings/ratings-taglib/src/main/resources/META-INF/resources/js/components/RatingsStars.js
@@ -15,6 +15,7 @@
 import ClayButton from '@clayui/button';
 import ClayDropDown from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
+import ClayLayout from '@clayui/layout';
 import {useIsMounted} from 'frontend-js-react-web';
 import PropTypes from 'prop-types';
 import React, {useCallback, useState} from 'react';
@@ -136,8 +137,12 @@ const RatingsStars = ({
 	};
 
 	return (
-		<div className="autofit-padded-no-gutters autofit-row autofit-row-center ratings ratings-stars">
-			<div className="autofit-col">
+		<ClayLayout.ContentRow
+			className="ratings ratings-stars"
+			noGutters
+			verticalAlign="center"
+		>
+			<ClayLayout.ContentCol>
 				<ClayDropDown
 					active={isDropdownOpen}
 					menuElementAttrs={{
@@ -204,8 +209,9 @@ const RatingsStars = ({
 						</ClayDropDown.Item>
 					</ClayDropDown.ItemList>
 				</ClayDropDown>
-			</div>
-			<div className="autofit-col">
+			</ClayLayout.ContentCol>
+
+			<ClayLayout.ContentCol>
 				<span className="ratings-stars-average">
 					<span className="inline-item inline-item-before">
 						<ClayIcon
@@ -224,8 +230,8 @@ const RatingsStars = ({
 					</span>
 					<span className="sr-only">{getSrAverageMessage()}</span>
 				</span>
-			</div>
-		</div>
+			</ClayLayout.ContentCol>
+		</ClayLayout.ContentRow>
 	);
 };
 

--- a/modules/apps/site-navigation/site-navigation-admin-web/package.json
+++ b/modules/apps/site-navigation/site-navigation-admin-web/package.json
@@ -3,6 +3,7 @@
 		"@clayui/button": "3.3.1",
 		"@clayui/drop-down": "3.4.3",
 		"@clayui/icon": "3.0.5",
+		"@clayui/layout": "3.0.1",
 		"frontend-js-web": "*",
 		"metal-dom": "2.16.8",
 		"metal-drag-drop": "3.3.1",

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/js/ContextualSidebar.js
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/js/ContextualSidebar.js
@@ -14,6 +14,7 @@
 
 import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
+import ClayLayout from '@clayui/layout';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import {useIsMounted, useTimeout} from 'frontend-js-react-web';
 import {fetch, objectToFormData} from 'frontend-js-web';
@@ -180,15 +181,16 @@ function ContextualSidebar({
 			id={`${namespace}sidebar`}
 		>
 			<div className="sidebar-header">
-				<div className="autofit-row sidebar-section">
-					<div className="autofit-col autofit-col-expand">
+				<ClayLayout.ContentRow className="sidebar-section">
+					<ClayLayout.ContentCol expand>
 						<p className="component-title">
 							<span className="text-truncate-inline">
 								<span className="text-truncate">{title}</span>
 							</span>
 						</p>
-					</div>
-					<div className="autofit-col">
+					</ClayLayout.ContentCol>
+
+					<ClayLayout.ContentCol>
 						<ClayButton
 							displayType="unstyled"
 							monospaced
@@ -201,8 +203,8 @@ function ContextualSidebar({
 						>
 							<ClayIcon symbol="times" />
 						</ClayButton>
-					</div>
-				</div>
+					</ClayLayout.ContentCol>
+				</ClayLayout.ContentRow>
 			</div>
 
 			<div className="sidebar-body">

--- a/modules/apps/site-navigation/site-navigation-item-selector-web/package.json
+++ b/modules/apps/site-navigation/site-navigation-item-selector-web/package.json
@@ -2,6 +2,7 @@
 	"dependencies": {
 		"@clayui/button": "3.3.1",
 		"@clayui/form": "3.8.0",
+		"@clayui/layout": "3.0.1",
 		"frontend-js-components-web": "*",
 		"frontend-js-web": "*",
 		"react": "16.12.0"

--- a/modules/apps/site-navigation/site-navigation-item-selector-web/src/main/resources/META-INF/resources/js/SelectSiteNavigationMenuItem.es.js
+++ b/modules/apps/site-navigation/site-navigation-item-selector-web/src/main/resources/META-INF/resources/js/SelectSiteNavigationMenuItem.es.js
@@ -14,6 +14,7 @@
 
 import {ClayButtonWithIcon} from '@clayui/button';
 import {ClayInput} from '@clayui/form';
+import ClayLayout from '@clayui/layout';
 import {Treeview} from 'frontend-js-components-web';
 import React, {useCallback, useState} from 'react';
 
@@ -46,7 +47,7 @@ const SelectSiteNavigationMenuItem = ({itemSelectorSaveEvent, nodes}) => {
 	};
 
 	return (
-		<div className="container-fluid-1280">
+		<ClayLayout.ContainerFluid>
 			<nav className="collapse-basic-search navbar navbar-default navbar-no-collapse">
 				<ClayInput.Group className="basic-search">
 					<ClayInput.GroupItem prepend>
@@ -73,7 +74,7 @@ const SelectSiteNavigationMenuItem = ({itemSelectorSaveEvent, nodes}) => {
 				nodes={nodes}
 				onSelectedNodesChange={handleSelectionChange}
 			/>
-		</div>
+		</ClayLayout.ContainerFluid>
 	);
 };
 


### PR DESCRIPTION
This is a simple code replacement applied to the js files. The new Clay layout components are rendering correctly
<img width="1440" alt="Screenshot 2020-06-09 at 11 36 39" src="https://user-images.githubusercontent.com/46778114/84143948-b98b1d00-aa57-11ea-9db6-973af49d4008.png">
(`edu` class is used as test)

In the previous pr (https://github.com/eduardoallegrini/liferay-portal/pull/85#discussion_r435308547) I wasn't sure about the changes in the product-navigation-product-menu-web so I tried again and I decided to remove those changes
<img width="1437" alt="Screenshot 2020-06-09 at 12 23 17" src="https://user-images.githubusercontent.com/46778114/84144475-97de6580-aa58-11ea-866e-d563d3347cc6.png">
<img width="1439" alt="Screenshot 2020-06-09 at 12 24 42" src="https://user-images.githubusercontent.com/46778114/84144503-a036a080-aa58-11ea-8e93-9f95a5dd140c.png">
