### PR TITLE
LPS-115551 - Add border color light in admin and classic themes

### DIFF
--- a/modules/.releng/test/jenkins-results-parser/artifact.properties
+++ b/modules/.releng/test/jenkins-results-parser/artifact.properties
@@ -1,4 +1,4 @@
-artifact.git.id=f2882dd0d6b449f89908026647ce98538dd67a83
-artifact.sources-commercial.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.jenkins.results.parser/1.0.630/com.liferay.jenkins.results.parser-1.0.630-sources-commercial.jar
-artifact.sources.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.jenkins.results.parser/1.0.630/com.liferay.jenkins.results.parser-1.0.630-sources.jar
-artifact.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.jenkins.results.parser/1.0.630/com.liferay.jenkins.results.parser-1.0.630.jar
+artifact.git.id=8dc8f9e542aecdc3fd43f259f0b0f09bc140766b
+artifact.sources-commercial.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.jenkins.results.parser/1.0.631/com.liferay.jenkins.results.parser-1.0.631-sources-commercial.jar
+artifact.sources.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.jenkins.results.parser/1.0.631/com.liferay.jenkins.results.parser-1.0.631-sources.jar
+artifact.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.jenkins.results.parser/1.0.631/com.liferay.jenkins.results.parser-1.0.631.jar

--- a/modules/.releng/test/jenkins-results-parser/artifact.properties
+++ b/modules/.releng/test/jenkins-results-parser/artifact.properties
@@ -1,4 +1,4 @@
-artifact.git.id=8dc8f9e542aecdc3fd43f259f0b0f09bc140766b
-artifact.sources-commercial.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.jenkins.results.parser/1.0.631/com.liferay.jenkins.results.parser-1.0.631-sources-commercial.jar
-artifact.sources.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.jenkins.results.parser/1.0.631/com.liferay.jenkins.results.parser-1.0.631-sources.jar
-artifact.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.jenkins.results.parser/1.0.631/com.liferay.jenkins.results.parser-1.0.631.jar
+artifact.git.id=022a8dfdb579e54ad5add59b477d767e0852ea33
+artifact.sources-commercial.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.jenkins.results.parser/1.0.632/com.liferay.jenkins.results.parser-1.0.632-sources-commercial.jar
+artifact.sources.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.jenkins.results.parser/1.0.632/com.liferay.jenkins.results.parser-1.0.632-sources.jar
+artifact.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.jenkins.results.parser/1.0.632/com.liferay.jenkins.results.parser-1.0.632.jar

--- a/modules/.releng/test/poshi-runner/poshi-runner-resources/artifact.properties
+++ b/modules/.releng/test/poshi-runner/poshi-runner-resources/artifact.properties
@@ -1,4 +1,4 @@
-artifact.git.id=d5ce62214eeba375b4501c3eecb0723ad579bf36
-artifact.sources-commercial.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.poshi.runner.resources/1.0.8/com.liferay.poshi.runner.resources-1.0.8-sources-commercial.jar
-artifact.sources.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.poshi.runner.resources/1.0.8/com.liferay.poshi.runner.resources-1.0.8-sources.jar
-artifact.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.poshi.runner.resources/1.0.8/com.liferay.poshi.runner.resources-1.0.8.jar
+artifact.git.id=59cee07e5f5ab5c6b7de9b3fc4bba98834208e0c
+artifact.sources-commercial.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.poshi.runner.resources/1.0.9/com.liferay.poshi.runner.resources-1.0.9-sources-commercial.jar
+artifact.sources.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.poshi.runner.resources/1.0.9/com.liferay.poshi.runner.resources-1.0.9-sources.jar
+artifact.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.poshi.runner.resources/1.0.9/com.liferay.poshi.runner.resources-1.0.9.jar

--- a/modules/.releng/test/poshi-runner/poshi-runner/artifact.properties
+++ b/modules/.releng/test/poshi-runner/poshi-runner/artifact.properties
@@ -1,4 +1,4 @@
-artifact.git.id=2cfac1fc5178423b2ad08f52e7773393dbb650b3
-artifact.sources-commercial.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.poshi.runner/1.0.269/com.liferay.poshi.runner-1.0.269-sources-commercial.jar
-artifact.sources.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.poshi.runner/1.0.269/com.liferay.poshi.runner-1.0.269-sources.jar
-artifact.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.poshi.runner/1.0.269/com.liferay.poshi.runner-1.0.269.jar
+artifact.git.id=59cee07e5f5ab5c6b7de9b3fc4bba98834208e0c
+artifact.sources-commercial.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.poshi.runner/1.0.270/com.liferay.poshi.runner-1.0.270-sources-commercial.jar
+artifact.sources.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.poshi.runner/1.0.270/com.liferay.poshi.runner-1.0.270-sources.jar
+artifact.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.poshi.runner/1.0.270/com.liferay.poshi.runner-1.0.270.jar

--- a/modules/apps/frontend-theme/frontend-theme-admin/src/css/_clay_variables.scss
+++ b/modules/apps/frontend-theme/frontend-theme-admin/src/css/_clay_variables.scss
@@ -1,4 +1,5 @@
 $bg-color: #f1f2f5;
+$border-color: #f1f2f5;
 
 $lead-font-weight: 400;
 $small-font-size: 0.875rem;

--- a/modules/apps/frontend-theme/frontend-theme-classic/src/css/_clay_variables.scss
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/css/_clay_variables.scss
@@ -1,4 +1,5 @@
 $body-bg: #fff;
+$border-color: #f1f2f5;
 $bright-color: #1865fb;
 $complementary-color: #30313f;
 $dark-color: #272833;

--- a/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/resources/META-INF/resources/control_menu/_control_menu.scss
+++ b/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/resources/META-INF/resources/control_menu/_control_menu.scss
@@ -71,6 +71,7 @@ a.control-menu-icon,
 
 .control-menu-level-1-light {
 	background-color: $control-menu-level-1-light-bg;
+	border-bottom: $control-menu-level-1-light-border;
 	color: $control-menu-level-1-light-color;
 
 	a:not(.dropdown-item),
@@ -80,6 +81,14 @@ a.control-menu-icon,
 		&:hover {
 			background-color: $control-menu-level-1-light-link-background-color;
 			color: $control-menu-level-1-light-link-hover-color;
+		}
+	}
+
+	> .container-fluid {
+		padding-bottom: $control-menu-level-1-padding - 1px;
+
+		@include media-breakpoint-up(sm) {
+			padding-bottom: $control-menu-level-1-padding-desktop - 1px;
 		}
 	}
 

--- a/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/resources/META-INF/resources/control_menu/_variables.scss
+++ b/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/resources/META-INF/resources/control_menu/_variables.scss
@@ -5,6 +5,9 @@ $control-menu-focus-box-shadow: 0 0 0 2px $white, 0 0 0 4px $primary-l1 !default
 
 $control-menu-css-transition: all 0.5s ease !default;
 
+$control-menu-level-1-padding: 8px;
+$control-menu-level-1-padding-desktop: 12px;
+
 $control-menu-level-1-active-border: $primary-l1 !default;
 $control-menu-level-1-active-border-width: 2px !default;
 $control-menu-level-1-bg: $dark-l1 !default;
@@ -14,6 +17,7 @@ $control-menu-level-1-link-hover-color: $white !default;
 $control-menu-level-1-link-background-color: fade_out($white, 0.97) !default;
 
 $control-menu-level-1-light-bg: $white !default;
+$control-menu-level-1-light-border: 1px solid $light;
 $control-menu-level-1-light-color: $gray-600 !default;
 $control-menu-level-1-light-link-color: $gray-600 !default;
 $control-menu-level-1-light-link-hover-color: $gray-800 !default;

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/java/com/liferay/portal/workflow/kaleo/designer/web/internal/application/list/KaleoDesignerPanelApp.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/java/com/liferay/portal/workflow/kaleo/designer/web/internal/application/list/KaleoDesignerPanelApp.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.portal.workflow.kaleo.designer.web.internal.application.list;
+
+import com.liferay.application.list.BasePanelApp;
+import com.liferay.application.list.PanelApp;
+import com.liferay.application.list.constants.PanelCategoryKeys;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Portlet;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.workflow.kaleo.designer.web.constants.KaleoDesignerPortletKeys;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Inácio Nery
+ */
+@Component(
+	immediate = true,
+	property = {
+		"panel.app.order:Integer=200",
+		"panel.category.key=" + PanelCategoryKeys.CONTROL_PANEL_WORKFLOW
+	},
+	service = PanelApp.class
+)
+public class KaleoDesignerPanelApp extends BasePanelApp {
+
+	@Override
+	public String getPortletId() {
+		return KaleoDesignerPortletKeys.KALEO_DESIGNER;
+	}
+
+	@Override
+	public boolean isShow(PermissionChecker permissionChecker, Group group)
+		throws PortalException {
+
+		return false;
+	}
+
+	@Override
+	@Reference(
+		target = "(javax.portlet.name=" + KaleoDesignerPortletKeys.KALEO_DESIGNER + ")",
+		unbind = "-"
+	)
+	public void setPortlet(Portlet portlet) {
+		super.setPortlet(portlet);
+	}
+
+}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/AssigneeMetricResourceTest.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/AssigneeMetricResourceTest.java
@@ -535,8 +535,9 @@ public class AssigneeMetricResourceTest
 
 		for (NodeMetric nodeMetric : nodeMetrics) {
 			_workflowMetricsRESTTestHelper.addNodeMetric(
-				assignee, testGroup.getCompanyId(), instanceSupplier, processId,
-				status, nodeMetric, "1.0");
+				assignee, testGroup.getCompanyId(), instanceSupplier,
+				nodeMetric, processId, status, TestPropsValues.getUser(),
+				"1.0");
 		}
 	}
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/AssigneeResourceTest.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/AssigneeResourceTest.java
@@ -17,6 +17,7 @@ package com.liferay.portal.workflow.metrics.rest.resource.v1_0.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.DataGuard;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Portal;
@@ -80,12 +81,14 @@ public class AssigneeResourceTest extends BaseAssigneeResourceTestCase {
 		Assignee assignee1 = randomAssignee();
 
 		_workflowMetricsRESTTestHelper.addTask(
-			assignee1, testGroup.getCompanyId(), _instance);
+			assignee1, testGroup.getCompanyId(), _instance,
+			TestPropsValues.getUser());
 
 		Assignee assignee2 = randomAssignee();
 
 		_workflowMetricsRESTTestHelper.addTask(
-			assignee2, testGroup.getCompanyId(), _instance);
+			assignee2, testGroup.getCompanyId(), _instance,
+			TestPropsValues.getUser());
 
 		Page<Assignee> page = assigneeResource.postProcessAssigneesPage(
 			_process.getId(), new AssigneeBulkSelection());

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/InstanceResourceTest.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/InstanceResourceTest.java
@@ -19,6 +19,7 @@ import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -167,7 +168,8 @@ public class InstanceResourceTest extends BaseInstanceResourceTestCase {
 
 		for (Assignee assignee : instance.getAssignees()) {
 			_workflowMetricsRESTTestHelper.addTask(
-				assignee, testGroup.getCompanyId(), instance);
+				assignee, testGroup.getCompanyId(), instance,
+				TestPropsValues.getUser());
 		}
 
 		if (instance.getCompleted()) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/NodeMetricResourceTest.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/NodeMetricResourceTest.java
@@ -18,6 +18,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.search.test.util.SearchTestRule;
@@ -425,7 +426,7 @@ public class NodeMetricResourceTest extends BaseNodeMetricResourceTestCase {
 			() -> _workflowMetricsRESTTestHelper.addInstance(
 				testGroup.getCompanyId(), Objects.equals(status, "COMPLETED"),
 				processId),
-			processId, status, nodeMetric, version);
+			nodeMetric, processId, status, TestPropsValues.getUser(), version);
 	}
 
 	@Override

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/RoleResourceTest.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/RoleResourceTest.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.util.RoleTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.search.test.util.SearchTestRule;
 import com.liferay.portal.test.rule.Inject;
@@ -131,7 +132,7 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 			() -> _workflowMetricsRESTTestHelper.addInstance(
 				testGroup.getCompanyId(), Objects.equals(status, "COMPLETED"),
 				processId),
-			processId, status);
+			processId, status, TestPropsValues.getUser());
 
 		return role;
 	}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/TaskResourceTest.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/TaskResourceTest.java
@@ -15,9 +15,8 @@
 package com.liferay.portal.workflow.metrics.rest.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
-import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.DataGuard;
-import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.search.test.util.SearchTestRule;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.workflow.metrics.rest.client.dto.v1_0.Assignee;
@@ -56,8 +55,6 @@ public class TaskResourceTest extends BaseTaskResourceTestCase {
 
 		_instance = _workflowMetricsRESTTestHelper.addInstance(
 			testGroup.getCompanyId(), false, _process.getId());
-
-		_user = UserTestUtil.addUser();
 	}
 
 	@After
@@ -93,11 +90,16 @@ public class TaskResourceTest extends BaseTaskResourceTestCase {
 
 		Task task2 = testGetProcessTask_addTask();
 
+		Task task3 = _workflowMetricsRESTTestHelper.addTask(
+			null, testGroup.getCompanyId(), _instance,
+			TestPropsValues.getUser());
+
 		page = taskResource.postProcessTasksPage(
 			Pagination.of(1, 10),
 			new TaskBulkSelection() {
 				{
-					assigneeIds = new Long[] {_user.getUserId()};
+					assigneeIds = new Long[] {TestPropsValues.getUserId()};
+					processId = _process.getId();
 				}
 			});
 
@@ -105,6 +107,20 @@ public class TaskResourceTest extends BaseTaskResourceTestCase {
 
 		assertEqualsIgnoringOrder(
 			Arrays.asList(task1, task2), (List<Task>)page.getItems());
+
+		page = taskResource.postProcessTasksPage(
+			Pagination.of(1, 10),
+			new TaskBulkSelection() {
+				{
+					assigneeIds = new Long[] {-1L};
+					processId = _process.getId();
+				}
+			});
+
+		Assert.assertEquals(1, page.getTotalCount());
+
+		assertEqualsIgnoringOrder(
+			Arrays.asList(task3), (List<Task>)page.getItems());
 
 		page = taskResource.postProcessTasksPage(
 			Pagination.of(1, 10),
@@ -114,10 +130,10 @@ public class TaskResourceTest extends BaseTaskResourceTestCase {
 				}
 			});
 
-		Assert.assertEquals(2, page.getTotalCount());
+		Assert.assertEquals(3, page.getTotalCount());
 
 		assertEqualsIgnoringOrder(
-			Arrays.asList(task1, task2), (List<Task>)page.getItems());
+			Arrays.asList(task1, task2, task3), (List<Task>)page.getItems());
 
 		page = taskResource.postProcessTasksPage(
 			Pagination.of(1, 10),
@@ -127,10 +143,10 @@ public class TaskResourceTest extends BaseTaskResourceTestCase {
 				}
 			});
 
-		Assert.assertEquals(2, page.getTotalCount());
+		Assert.assertEquals(3, page.getTotalCount());
 
 		assertEqualsIgnoringOrder(
-			Arrays.asList(task1, task2), (List<Task>)page.getItems());
+			Arrays.asList(task1, task2, task3), (List<Task>)page.getItems());
 
 		page = taskResource.postProcessTasksPage(
 			Pagination.of(1, 10),
@@ -176,7 +192,8 @@ public class TaskResourceTest extends BaseTaskResourceTestCase {
 			Pagination.of(0, 0),
 			new TaskBulkSelection() {
 				{
-					assigneeIds = new Long[] {_user.getUserId()};
+					assigneeIds = new Long[] {TestPropsValues.getUserId()};
+					processId = _process.getId();
 				}
 			});
 
@@ -184,6 +201,20 @@ public class TaskResourceTest extends BaseTaskResourceTestCase {
 
 		assertEqualsIgnoringOrder(
 			Arrays.asList(task1, task2), (List<Task>)page.getItems());
+
+		page = taskResource.postProcessTasksPage(
+			Pagination.of(0, 0),
+			new TaskBulkSelection() {
+				{
+					assigneeIds = new Long[] {-1L};
+					processId = _process.getId();
+				}
+			});
+
+		Assert.assertEquals(1, page.getTotalCount());
+
+		assertEqualsIgnoringOrder(
+			Arrays.asList(task3), (List<Task>)page.getItems());
 
 		page = taskResource.postProcessTasksPage(
 			Pagination.of(0, 0),
@@ -193,10 +224,10 @@ public class TaskResourceTest extends BaseTaskResourceTestCase {
 				}
 			});
 
-		Assert.assertEquals(2, page.getTotalCount());
+		Assert.assertEquals(3, page.getTotalCount());
 
 		assertEqualsIgnoringOrder(
-			Arrays.asList(task1, task2), (List<Task>)page.getItems());
+			Arrays.asList(task1, task2, task3), (List<Task>)page.getItems());
 
 		page = taskResource.postProcessTasksPage(
 			Pagination.of(0, 0),
@@ -206,10 +237,10 @@ public class TaskResourceTest extends BaseTaskResourceTestCase {
 				}
 			});
 
-		Assert.assertEquals(2, page.getTotalCount());
+		Assert.assertEquals(3, page.getTotalCount());
 
 		assertEqualsIgnoringOrder(
-			Arrays.asList(task1, task2), (List<Task>)page.getItems());
+			Arrays.asList(task1, task2, task3), (List<Task>)page.getItems());
 
 		page = taskResource.postProcessTasksPage(
 			Pagination.of(0, 0),
@@ -281,10 +312,10 @@ public class TaskResourceTest extends BaseTaskResourceTestCase {
 		return _workflowMetricsRESTTestHelper.addTask(
 			new Assignee() {
 				{
-					id = _user.getUserId();
+					id = TestPropsValues.getUserId();
 				}
 			},
-			testGroup.getCompanyId(), _instance);
+			testGroup.getCompanyId(), _instance, TestPropsValues.getUser());
 	}
 
 	@Override
@@ -305,12 +336,12 @@ public class TaskResourceTest extends BaseTaskResourceTestCase {
 	@Override
 	protected Task testPatchProcessTaskComplete_addTask() throws Exception {
 		return _workflowMetricsRESTTestHelper.addTask(
-			testGroup.getCompanyId(), _instance, randomPatchTask());
+			testGroup.getCompanyId(), _instance, randomPatchTask(),
+			TestPropsValues.getUser());
 	}
 
 	private Instance _instance;
 	private Process _process;
-	private User _user;
 
 	@Inject
 	private WorkflowMetricsRESTTestHelper _workflowMetricsRESTTestHelper;

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/helper/WorkflowMetricsRESTTestHelper.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/helper/WorkflowMetricsRESTTestHelper.java
@@ -20,6 +20,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -208,7 +209,7 @@ public class WorkflowMetricsRESTTestHelper {
 	public NodeMetric addNodeMetric(
 			Assignee assignee, long companyId,
 			UnsafeSupplier<Instance, Exception> instanceSuplier, long processId,
-			String status)
+			String status, User user)
 		throws Exception {
 
 		String randomString = RandomTestUtil.randomString();
@@ -230,14 +231,15 @@ public class WorkflowMetricsRESTTestHelper {
 		};
 
 		return addNodeMetric(
-			assignee, companyId, instanceSuplier, processId, status, task,
+			assignee, companyId, instanceSuplier, task, processId, status, user,
 			"1.0");
 	}
 
 	public NodeMetric addNodeMetric(
 			Assignee assignee, long companyId,
-			UnsafeSupplier<Instance, Exception> instanceSuplier, long processId,
-			String status, NodeMetric nodeMetric, String version)
+			UnsafeSupplier<Instance, Exception> instanceSuplier,
+			NodeMetric nodeMetric, long processId, String status, User user,
+			String version)
 		throws Exception {
 
 		Node node = addNode(
@@ -267,7 +269,7 @@ public class WorkflowMetricsRESTTestHelper {
 
 			addTask(
 				assignee, companyId, nodeMetric.getDurationAvg(), instance,
-				processId, node.getId(), taskId, node.getName());
+				node.getName(), node.getId(), processId, taskId, user);
 
 			if (instance.getCompleted()) {
 				completeInstance(companyId, instance);
@@ -434,19 +436,20 @@ public class WorkflowMetricsRESTTestHelper {
 			"taskId", taskId, "taskName", taskName);
 	}
 
-	public Task addTask(Assignee assignee, long companyId, Instance instance)
+	public Task addTask(
+			Assignee assignee, long companyId, Instance instance, User user)
 		throws Exception {
 
 		return addTask(
-			assignee, companyId, 0L, instance, instance.getProcessId(),
-			RandomTestUtil.randomLong(), RandomTestUtil.randomLong(),
-			RandomTestUtil.randomString());
+			assignee, companyId, 0L, instance, RandomTestUtil.randomString(),
+			RandomTestUtil.randomLong(), instance.getProcessId(),
+			RandomTestUtil.randomLong(), user);
 	}
 
 	public Task addTask(
 			Assignee assignee, long companyId, long durationAvg,
-			Instance instance, long processId, long nodeId, long taskId,
-			String name)
+			Instance instance, String name, long nodeId, long processId,
+			long taskId, User user)
 		throws Exception {
 
 		Task task = new Task();
@@ -467,14 +470,14 @@ public class WorkflowMetricsRESTTestHelper {
 		task.setProcessId(processId);
 		task.setProcessVersion("1.0");
 
-		return addTask(companyId, instance, task);
+		return addTask(companyId, instance, task, user);
 	}
 
-	public Task addTask(long companyId, Instance instance, Task task)
+	public Task addTask(long companyId, Instance instance, Task task, User user)
 		throws Exception {
 
-		Long[] assigneeIds = null;
-		String assigneeType = null;
+		Long[] assigneeIds = ArrayUtil.toArray(user.getRoleIds());
+		String assigneeType = Role.class.getName();
 
 		Assignee assignee = task.getAssignee();
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/shared/components/filter/FilterItem.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/shared/components/filter/FilterItem.es.js
@@ -10,7 +10,7 @@
  */
 
 import getClassName from 'classnames';
-import React from 'react';
+import React, {useState} from 'react';
 
 const FilterItem = ({
 	active = false,
@@ -23,6 +23,8 @@ const FilterItem = ({
 	onClick,
 	...otherProps
 }) => {
+	const [checked, setChecked] = useState(active);
+
 	const classes = {
 		control: getClassName(
 			'custom-control',
@@ -37,16 +39,21 @@ const FilterItem = ({
 		),
 	};
 
+	const onClickFilter = (event) => {
+		onClick(event);
+		setChecked(!checked);
+	};
+
 	return (
 		<>
 			<div
 				className={classes.dropdown}
 				data-testid="filterItem"
-				onClick={onClick}
+				onClick={onClickFilter}
 			>
 				<div className={classes.control}>
 					<input
-						checked={active}
+						checked={checked}
 						className="custom-control-input"
 						type={multiple ? 'checkbox' : 'radio'}
 					/>

--- a/modules/test/jenkins-results-parser/bnd.bnd
+++ b/modules/test/jenkins-results-parser/bnd.bnd
@@ -1,3 +1,3 @@
 Bundle-Name: Liferay Jenkins Results Parser
 Bundle-SymbolicName: com.liferay.jenkins.results.parser
-Bundle-Version: 1.0.632
+Bundle-Version: 1.0.633

--- a/modules/test/jenkins-results-parser/bnd.bnd
+++ b/modules/test/jenkins-results-parser/bnd.bnd
@@ -1,3 +1,3 @@
 Bundle-Name: Liferay Jenkins Results Parser
 Bundle-SymbolicName: com.liferay.jenkins.results.parser
-Bundle-Version: 1.0.631
+Bundle-Version: 1.0.632

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -680,25 +680,33 @@ public class GitWorkingDirectory {
 			(remoteGitRef instanceof RemoteGitBranch) &&
 			remoteURL.contains("github.com:liferay/")) {
 
-			LocalGitBranch liferayGitHubLocalGitBranch = createLocalGitBranch(
-				JenkinsResultsParserUtil.combine(
-					"temp-", remoteGitRef.getName()),
-				true, remoteGitRef.getSHA());
+			String upstreamBranchSHA = getRemoteGitBranchSHA(
+				remoteGitRef.getName(), getUpstreamGitRemote());
 
-			List<GitRemote> gitHubDevGitRemotes =
-				GitHubDevSyncUtil.getGitHubDevGitRemotes(this);
+			if ((upstreamBranchSHA != null) &&
+				upstreamBranchSHA.equals(remoteGitRef.getSHA())) {
 
-			try {
-				GitHubDevSyncUtil.pushToAllRemotes(
-					true, liferayGitHubLocalGitBranch, remoteGitRef.getName(),
-					gitHubDevGitRemotes);
-			}
-			finally {
-				if (localGitBranch == null) {
-					deleteLocalGitBranch(liferayGitHubLocalGitBranch);
+				LocalGitBranch liferayGitHubLocalGitBranch =
+					createLocalGitBranch(
+						JenkinsResultsParserUtil.combine(
+							"temp-", remoteGitRef.getName()),
+						true, remoteGitRef.getSHA());
+
+				List<GitRemote> gitHubDevGitRemotes =
+					GitHubDevSyncUtil.getGitHubDevGitRemotes(this);
+
+				try {
+					GitHubDevSyncUtil.pushToAllRemotes(
+						true, liferayGitHubLocalGitBranch,
+						remoteGitRef.getName(), gitHubDevGitRemotes);
 				}
+				finally {
+					if (localGitBranch == null) {
+						deleteLocalGitBranch(liferayGitHubLocalGitBranch);
+					}
 
-				removeGitRemotes(gitHubDevGitRemotes);
+					removeGitRemotes(gitHubDevGitRemotes);
+				}
 			}
 		}
 

--- a/modules/test/poshi-runner/poshi-runner-resources/bnd.bnd
+++ b/modules/test/poshi-runner/poshi-runner-resources/bnd.bnd
@@ -1,3 +1,3 @@
 Bundle-Name: Liferay Poshi Runner Resources
 Bundle-SymbolicName: com.liferay.poshi.runner.resources
-Bundle-Version: 1.0.9
+Bundle-Version: 1.0.10

--- a/modules/test/poshi-runner/poshi-runner/bnd.bnd
+++ b/modules/test/poshi-runner/poshi-runner/bnd.bnd
@@ -1,3 +1,3 @@
 Bundle-Name: Liferay Poshi Runner
 Bundle-SymbolicName: com.liferay.poshi.runner
-Bundle-Version: 1.0.270
+Bundle-Version: 1.0.271

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/LiferaySeleniumUtil.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/LiferaySeleniumUtil.java
@@ -732,16 +732,34 @@ public class LiferaySeleniumUtil {
 
 		if (!_javaScriptExceptions.isEmpty()) {
 			for (Exception exception : _javaScriptExceptions) {
+				String message = exception.getMessage();
+
+				if (Validator.isNotNull(message) &&
+					(message.length() > _CHARS_EXCEPTION_MESSAGE_SIZE_MAX)) {
+
+					message = message.substring(
+						0, _CHARS_EXCEPTION_MESSAGE_SIZE_MAX);
+				}
+
 				sb.append("<value><![CDATA[");
-				sb.append(exception.getMessage());
+				sb.append(message);
 				sb.append("]]></value>\n");
 			}
 		}
 
 		if (!_liferayExceptions.isEmpty()) {
 			for (Exception exception : _liferayExceptions) {
+				String message = exception.getMessage();
+
+				if (Validator.isNotNull(message) &&
+					(message.length() > _CHARS_EXCEPTION_MESSAGE_SIZE_MAX)) {
+
+					message = message.substring(
+						0, _CHARS_EXCEPTION_MESSAGE_SIZE_MAX);
+				}
+
 				sb.append("<value><![CDATA[");
-				sb.append(exception.getMessage());
+				sb.append(message);
 				sb.append("]]></value>\n");
 			}
 		}
@@ -771,6 +789,8 @@ public class LiferaySeleniumUtil {
 	}
 
 	private static final long _BYTES_MAX_SIZE_CONSOLE_LOG = 20 * 1024 * 1024;
+
+	private static final int _CHARS_EXCEPTION_MESSAGE_SIZE_MAX = 2500;
 
 	private static final List<String> _errorTimestamps = new ArrayList<>();
 	private static final List<Exception> _javaScriptExceptions =

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/LiferaySeleniumUtil.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/LiferaySeleniumUtil.java
@@ -732,6 +732,8 @@ public class LiferaySeleniumUtil {
 
 		if (!_javaScriptExceptions.isEmpty()) {
 			for (Exception exception : _javaScriptExceptions) {
+				sb.append("<value><![CDATA[");
+
 				String message = exception.getMessage();
 
 				if (Validator.isNotNull(message) &&
@@ -741,14 +743,16 @@ public class LiferaySeleniumUtil {
 						0, _CHARS_EXCEPTION_MESSAGE_SIZE_MAX);
 				}
 
-				sb.append("<value><![CDATA[");
 				sb.append(message);
+
 				sb.append("]]></value>\n");
 			}
 		}
 
 		if (!_liferayExceptions.isEmpty()) {
 			for (Exception exception : _liferayExceptions) {
+				sb.append("<value><![CDATA[");
+
 				String message = exception.getMessage();
 
 				if (Validator.isNotNull(message) &&
@@ -758,8 +762,8 @@ public class LiferaySeleniumUtil {
 						0, _CHARS_EXCEPTION_MESSAGE_SIZE_MAX);
 				}
 
-				sb.append("<value><![CDATA[");
 				sb.append(message);
+
 				sb.append("]]></value>\n");
 			}
 		}


### PR DESCRIPTION
New design for control-menu-light version, with bottom border in light color:

![image](https://user-images.githubusercontent.com/7963804/84777572-0899fa80-afe2-11ea-8fcb-d36b1c914d2b.png)

To use the same border in modals and navbars with management-bar below, developers will need to add to navbar the class called `border-bottom` (actually they are currently doing this).

To validate the design you can go to navigate to any section of applications (Global menu).

![image](https://user-images.githubusercontent.com/7963804/84777785-57479480-afe2-11ea-828e-bd8e1b61db62.png)
