### PR TITLE
 (WIP) LPS-116193 As a developer I can specify custom tokens so that the style editor provides a form to edit those tokens instead of the Liferay-standard ones

### DIFF
--- a/design_tokens_example.json
+++ b/design_tokens_example.json
@@ -1,0 +1,106 @@
+{
+	"tokenSetCategories" : [
+		{
+			"label": {
+				"key": "general"
+			},
+			"tokenSets": [
+				{
+					"label": {
+						"key": "links"
+					},
+					"tokens": [
+						{
+							"cssVariable": "$link-color",
+							"label": {
+								"key": "link-color"
+							},
+							"name": "linkColor",
+							"type": "Color"
+						},
+						{
+							"cssVariable": "$link-text-decoration",
+							"label": {
+								"key": "text-underline"
+							},
+							"name": "linkTextUnderline",
+							"type": "Boolean"
+						},
+						{
+							"cssVariable": "$link-hover-color",
+							"label": {
+								"value_i18n": {
+									"en_US": "Link Hover Color"
+								}
+							},
+							"name": "linkHoverColor",
+							"type": "Color"
+						},
+						{
+							"cssVariable": "$link-hover-text-decoration",
+							"label": {
+								"key": "text-underline"
+							},
+							"name": "linkHoverTextUnderline",
+							"type": "Boolean"
+						}
+					]
+				}
+			]
+		},
+		{
+			"label": {
+				"key": "layout"
+			},
+			"tokenSets": [
+				{
+					"label": {
+						"key": "grid"
+					},
+					"tokens": [
+						{
+							"cssVariable": "$grid-columns",
+							"label": {
+								"key": "number-of-columns"
+							},
+							"name": "gridNumberOfColumns",
+							"type": "Number"
+						},
+						{
+							"cssVariable": "$grid-gutter-width",
+							"label": {
+								"key": "gutter"
+							},
+							"name": "gridGutterNumberOfPixels",
+							"type": "Number"
+						},
+						{
+							"cssVariable": "$some-container-related-variable",
+							"label": {
+								"value_i18n": {
+									"key": "default-container"
+								}
+							},
+							"name": "gridDefaultContainer",
+							"type": "String",
+							"validValues": [
+								{
+									"label": {
+										"key": "fixed-width"
+									},
+									"value" : "FixedWidth"
+								},
+								{
+									"label": {
+										"key": "fluid"
+									},
+									"value" : "Fluid"
+								}
+							]
+						}
+					]
+				}
+			]
+		}
+	]
+}

--- a/design_tokens_json_schema.json
+++ b/design_tokens_json_schema.json
@@ -1,0 +1,141 @@
+{
+	"$id": "http://example.com/root.json",
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"additionalProperties": false,
+	"definitions": {
+		"Label" : {
+			"properties": {
+				"key": {
+					"description": "Language Key for the label",
+					"title": "Key",
+					"type": "string"
+				},
+				"value": {
+					"description": "Value returned when a specific locale is requested",
+					"title": "Value",
+					"type": "string"
+				},
+				"value_i18n": {
+					"description": "Localized Values returned when multiple locales are requested",
+					"additionalProperties": {
+						"type": "string"
+					},
+					"title": "Localized Value",
+					"type": "object"
+				}
+			}
+		},
+		"Token" : {
+			"additionalProperties": false,
+			"properties": {
+				"repeatable": {
+					"title": "Repeatable Flag",
+					"type": "boolean"
+				},
+				"cssVariable": {
+					"title": "Associated CSS Variable",
+					"type": "string"
+				},
+				"name": {
+					"title": "Name of the Token",
+					"type": "string"
+				},
+				"label": {
+					"$ref": "#/definitions/Label"
+				},
+				"type": {
+					"enum": [
+						"Boolean",
+						"Color",
+						"Number",
+						"String"
+					],
+					"title": "The Type of the Token",
+					"type": "string"
+				},
+				"validValues": {
+					"items": {
+						"additionalProperties": false,
+						"not": {
+							"type": "null"
+						},
+						"properties": {
+							"label": {
+								"$ref": "#/definitions/Label"
+							},
+							"value": {
+								"title": "Value",
+								"type": "string"
+							}
+						},
+						"required": [
+							"value"
+						],
+						"title": "Valid Value",
+						"type": "object"
+					},
+					"minItems": 1,
+					"title": "Valid Values",
+					"type": "array"
+				}
+			},
+			"required": [
+				"name"
+			]
+		},
+		"TokenSetCategory" : {
+			"additionalProperties": false,
+			"description": "Grouping of Token Sets",
+			"properties": {
+				"label": {
+					"$ref": "#/definitions/Label"
+				},
+				"tokenSets": {
+					"items": {
+						"$ref": "#/definitions/TokenSet"
+					},
+					"title": "Token Sets",
+					"type": "array"
+				}
+			},
+			"required": [
+				"tokenSets"
+			],
+			"title": "Token Set Category"
+		},
+		"TokenSet" : {
+			"additionalProperties": false,
+			"description": "Grouping of Tokens",
+			"properties": {
+				"label": {
+					"$ref": "#/definitions/Label"
+				},
+				"tokens": {
+					"items": {
+						"$ref": "#/definitions/Token"
+					},
+					"title": "Tokens",
+					"type": "array"
+				}
+			},
+			"required": [
+				"tokens"
+			],
+			"title": "Token Set"
+		}
+	},
+	"properties": {
+		"tokenSetCategories": {
+			"items": {
+				"$ref": "#/definitions/TokenSetCategory"
+			},
+			"title": "Token Set Categories",
+			"type": "array"
+		}
+	},
+	"required": [
+		"tokenSetCategories"
+	],
+	"title": "The Design Tokens Schema",
+	"type": "object"
+}


### PR DESCRIPTION
Hi @jbalsas.

This is a first draft of the JSON schema specification for Design Tokens.

It should cover the cases specified in the [designs](https://docs.google.com/document/d/1Tn8ycrPZQkEtzKNZPF5k7PCeMR6Pkc0Ke7RYW-yiqKI/edit#) except for Layout > Responsive Configuration > Viewport Sizes, where a repeatable "element" is composed of 3 tokens (Breakpoint (min-width), Container (max-width) and Default Layout).

I'll keep working on seeing how we can adapt the schema to be able to cover that case.

Feedback is greatly welcomed!