### PR TITLE
LPS-139131 Fix iFrameURL once again

### DIFF
--- a/modules/apps/remote-app/remote-app-web/src/main/resources/META-INF/resources/admin/edit_remote_app_entry.jsp
+++ b/modules/apps/remote-app/remote-app-web/src/main/resources/META-INF/resources/admin/edit_remote_app_entry.jsp
@@ -70,7 +70,7 @@ renderResponse.setTitle((remoteAppEntry == null) ? LanguageUtil.get(request, "ne
 				cssClass='<%= ((remoteAppEntry == null) || RemoteAppConstants.TYPE_IFRAME.equals(remoteAppEntry.getType())) ? StringPool.BLANK : "d-none" %>'
 				id='<%= liferayPortletResponse.getNamespace() + "_type_iframe" %>'
 			>
-				<aui:input fieldParam="iFrameURL" label="url" name="IFrameURL">
+				<aui:input label="url" name="iFrameURL">
 					<aui:validator name="url" />
 				</aui:input>
 			</liferay-frontend:fieldset>


### PR DESCRIPTION
The field is named iFrameURL (not IFrameURL, that's the method-name, not the
field, see service.xml and portlet-model-hints.xml), so there's no need to
specify fieldParam.